### PR TITLE
Benchmark JsonReader against System.Text.Json

### DIFF
--- a/Jacob.sln
+++ b/Jacob.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Jacob", "src\Jacob.csproj",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Jacob.Tests", "tests\Jacob.Tests.csproj", "{87E991E5-6484-4EB4-AAEE-E9F5340B58DE}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Jacob.Benchmarks", "benchmarks\Jacob.Benchmarks.csproj", "{F9651A10-29E2-4CC3-AC34-161211700A46}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{3A64A278-7585-47D7-B39B-3DB4539DD3D5}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
@@ -55,6 +57,18 @@ Global
 		{87E991E5-6484-4EB4-AAEE-E9F5340B58DE}.Release|x64.Build.0 = Release|Any CPU
 		{87E991E5-6484-4EB4-AAEE-E9F5340B58DE}.Release|x86.ActiveCfg = Release|Any CPU
 		{87E991E5-6484-4EB4-AAEE-E9F5340B58DE}.Release|x86.Build.0 = Release|Any CPU
+		{F9651A10-29E2-4CC3-AC34-161211700A46}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F9651A10-29E2-4CC3-AC34-161211700A46}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F9651A10-29E2-4CC3-AC34-161211700A46}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F9651A10-29E2-4CC3-AC34-161211700A46}.Debug|x64.Build.0 = Debug|Any CPU
+		{F9651A10-29E2-4CC3-AC34-161211700A46}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F9651A10-29E2-4CC3-AC34-161211700A46}.Debug|x86.Build.0 = Debug|Any CPU
+		{F9651A10-29E2-4CC3-AC34-161211700A46}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F9651A10-29E2-4CC3-AC34-161211700A46}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F9651A10-29E2-4CC3-AC34-161211700A46}.Release|x64.ActiveCfg = Release|Any CPU
+		{F9651A10-29E2-4CC3-AC34-161211700A46}.Release|x64.Build.0 = Release|Any CPU
+		{F9651A10-29E2-4CC3-AC34-161211700A46}.Release|x86.ActiveCfg = Release|Any CPU
+		{F9651A10-29E2-4CC3-AC34-161211700A46}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/benchmarks/AssemblyInfo.cs
+++ b/benchmarks/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+// Copyright (c) 2021 Atif Aziz.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+[assembly: System.CLSCompliant(false)]

--- a/benchmarks/Benchmarks.cs
+++ b/benchmarks/Benchmarks.cs
@@ -1,0 +1,155 @@
+// Copyright (c) 2021 Atif Aziz.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Jacob.Benchmarks;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+[MemoryDiagnoser]
+public class JsonBenchmarks
+{
+    byte[]? jsonDataBytes;
+
+    public static readonly string WeatherMeasurementDataJson = Strictify(@"{
+        date: '2022-01-31',
+        id: 'Zuerich Uetliberg',
+        location: {latitude: 47.3494991, longitude: 8.4832738},
+        measurements: [{temperature: 6.35, precipitation: 0.23}]
+    }");
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        this.jsonDataBytes = Encoding.UTF8.GetBytes(WeatherMeasurementDataJson);
+    }
+
+    [Benchmark]
+    public void JsonReaderBenchmark()
+    {
+        var reader = new Utf8JsonReader(jsonDataBytes);
+        _ = reader.Read();
+        _ = StationReportReader.Read(ref reader);
+    }
+
+    [Benchmark]
+    public void SystemTextBenchmark()
+    {
+        var weatherMeasurementData = System.Text.Json.JsonSerializer.Deserialize<WeatherMeasurementData>(jsonDataBytes);
+        var measurements = weatherMeasurementData!.Measurements!.Select(m => (new Measurement(MeasurementKind.Temperature, m.TemperatureCelsius), new Measurement(MeasurementKind.Precipitation, m.PrecipitationMm)));
+        _ = new StationReport(weatherMeasurementData!.Date, new Station(weatherMeasurementData!.StationId!, (weatherMeasurementData!.Location!.Latitude, weatherMeasurementData!.Location.Longitude)), measurements.SelectMany(m => new[] { m.Item1, m.Item2 }).ToList());
+    }
+
+    [Benchmark]
+    public void SourceGeneratedBenchmark()
+    {
+        var weatherMeasurementData = System.Text.Json.JsonSerializer.Deserialize(jsonDataBytes, SourceGenerationContext.Default.WeatherMeasurementData);
+        var measurements = weatherMeasurementData!.Measurements!.Select(m => (new Measurement(MeasurementKind.Temperature, m.TemperatureCelsius), new Measurement(MeasurementKind.Precipitation, m.PrecipitationMm)));
+        _ = new StationReport(weatherMeasurementData!.Date, new Station(weatherMeasurementData!.StationId!, (weatherMeasurementData!.Location!.Latitude, weatherMeasurementData!.Location.Longitude)), measurements.SelectMany(m => new[] { m.Item1, m.Item2 }).ToList());
+    }
+
+    private static string Strictify(string json) =>
+        JToken.Parse(json).ToString(Formatting.None);
+
+    internal static readonly IJsonReader<(double, double), JsonReadResult<(double, double)>> LocationReader =
+    Jacob.JsonReader.Object(
+        Jacob.JsonReader.Property("latitude", Jacob.JsonReader.Double()),
+        Jacob.JsonReader.Property("longitude", Jacob.JsonReader.Double()),
+        ValueTuple.Create);
+
+    internal static readonly IJsonReader<(Measurement, Measurement), JsonReadResult<(Measurement, Measurement)>> MeasurementReader =
+        Jacob.JsonReader.Object(
+            Jacob.JsonReader.Property("temperature", Jacob.JsonReader.Double()),
+            Jacob.JsonReader.Property("precipitation", Jacob.JsonReader.Double()),
+            (temperature, precipitation) => (new Measurement(MeasurementKind.Temperature, temperature), new Measurement(MeasurementKind.Precipitation, precipitation)));
+
+    internal static readonly IJsonReader<StationReport, JsonReadResult<StationReport>> StationReportReader =
+        Jacob.JsonReader.Object(
+            Jacob.JsonReader.Property("date", Jacob.JsonReader.DateTime()),
+            Jacob.JsonReader.Property("id", Jacob.JsonReader.String()),
+            Jacob.JsonReader.Property("location", LocationReader),
+            Jacob.JsonReader.Property("measurements", Jacob.JsonReader.Array(MeasurementReader)),
+            (date, id, location, measurements) => new StationReport(date, new Station(id, location), measurements.SelectMany(m => new[] { m.Item1, m.Item2 }).ToList()));
+
+    static void Main(string[] args) => BenchmarkSwitcher.FromAssembly(typeof(JsonBenchmarks).Assembly).Run(args);
+}
+
+[JsonSourceGenerationOptions(WriteIndented = false)]
+[JsonSerializable(typeof(WeatherMeasurementData))]
+internal partial class SourceGenerationContext : JsonSerializerContext
+{ }
+
+class WeatherMeasurementData
+{
+    [JsonPropertyName("date")]
+    public DateTime Date { get; set; }
+
+    [JsonPropertyName("id")]
+    public string? StationId { get; set; }
+
+    [JsonPropertyName("location")]
+    public LocationData? Location { get; set; }
+
+    [JsonPropertyName("measurements")]
+    public IList<MeasurementData>? Measurements { get; set; }
+}
+
+class LocationData
+{
+    [JsonPropertyName("latitude")]
+    public double Latitude { get; set; }
+
+    [JsonPropertyName("longitude")]
+    public double Longitude { get; set; }
+}
+
+class MeasurementData
+{
+    [JsonPropertyName("temperature")]
+    public double TemperatureCelsius { get; set; }
+
+    [JsonPropertyName("precipitation")]
+    public double PrecipitationMm { get; set; }
+}
+
+class StationReport
+{
+    public DateTime Date { get; }
+    internal Station Station { get; }
+    internal List<Measurement> Measurements { get; }
+
+    public StationReport(DateTime date, Station station, List<Measurement> measurements)
+    {
+        Date = date;
+        Station = station;
+        Measurements = measurements;
+    }
+}
+
+class Station
+{
+    internal string Id { get; }
+    internal (double, double) Location { get; }
+
+    public Station(string id, (double, double) location)
+    {
+        Id = id;
+        Location = location;
+    }
+}
+
+record struct Measurement(MeasurementKind Kind, double Value);
+
+enum MeasurementKind
+{
+    Temperature, Precipitation
+}

--- a/benchmarks/Jacob.Benchmarks.csproj
+++ b/benchmarks/Jacob.Benchmarks.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <Configuration>Release</Configuration>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Using Include="Jacob" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\Jacob.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## What is changed
Adds benchmarking code comparing JsonReader against System.Text.Json Deserialize method. 

## How it's changed
- Making use of BenchmarkDotNet
- Benchmarks are a separate project/namespace
- All tests are running in a single suite. 

The results are as follows:

|                   Method |     Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------- |---------:|----------:|----------:|-------:|------:|------:|----------:|
|      JsonReaderBenchmark | 2.078 us | 0.0394 us | 0.0369 us | 0.0763 |     - |     - |     656 B |
|      SystemTextBenchmark | 1.911 us | 0.0377 us | 0.0353 us | 0.1297 |     - |     - |    1088 B |
| SourceGeneratedBenchmark | 1.915 us | 0.0317 us | 0.0296 us | 0.1297 |     - |     - |    1088 B |
