### PR TITLE
Github API sample benchmark

### DIFF
--- a/bench/GithubApiBenchmark.cs
+++ b/bench/GithubApiBenchmark.cs
@@ -19,42 +19,38 @@ using BenchmarkDotNet.Attributes;
 public class GithubApiBenchmark
 {
     static readonly MergeBranchResponse TestData =
-        new(new Uri(
-                "https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e"),
+        new(new Uri("https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e"),
             "6dcb09b5b57875f334f61aebed695e2e4193db5e",
-            new Commit(
-                new Uri(
-                    "https://api.github.com/repos/octocat/Hello-World/git/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e"),
-                new Author("Monalisa Octocat", "mona@github.com",
-                    DateTime.Parse("2011-04-14T16:00:49Z", CultureInfo.InvariantCulture)),
-                new Author("Monalisa Octocat", "mona@github.com",
-                    DateTime.Parse("2011-04-14T16:00:49Z", CultureInfo.InvariantCulture)),
-                "fix all the bugs",
-                12));
+            new Commit(new Uri("https://api.github.com/repos/octocat/Hello-World/git/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e"),
+                       new Author("Monalisa Octocat", "mona@github.com",
+                                  DateTime.Parse("2011-04-14T16:00:49Z",
+                                                 CultureInfo.InvariantCulture)),
+                       new Author("Monalisa Octocat", "mona@github.com",
+                                  DateTime.Parse("2011-04-14T16:00:49Z",
+                                                 CultureInfo.InvariantCulture)),
+                       "fix all the bugs",
+                       12));
 
     private static readonly IJsonReader<Author> AuthorJsonReader =
-        JsonReader.Object(
-            JsonReader.Property("name", JsonReader.String()),
-            JsonReader.Property("email", JsonReader.String()),
-            JsonReader.Property("date", JsonReader.DateTime()),
-            (name, email, date) => new Author(name, email, date));
+        JsonReader.Object(JsonReader.Property("name", JsonReader.String()),
+                          JsonReader.Property("email", JsonReader.String()),
+                          JsonReader.Property("date", JsonReader.DateTime()),
+                          (name, email, date) => new Author(name, email, date));
 
     private static readonly IJsonReader<Commit> CommitJsonReader =
-        JsonReader.Object(
-            JsonReader.Property("url", from s in JsonReader.String() select new Uri(s)),
-            JsonReader.Property("author", AuthorJsonReader),
-            JsonReader.Property("committer", AuthorJsonReader),
-            JsonReader.Property("message", JsonReader.String()),
-            JsonReader.Property("comment_count", JsonReader.Int32()),
-            (url, author, committer, message, commentCount) =>
-                new Commit(url, author, committer, message, commentCount));
+        JsonReader.Object(JsonReader.Property("url", from s in JsonReader.String() select new Uri(s)),
+                          JsonReader.Property("author", AuthorJsonReader),
+                          JsonReader.Property("committer", AuthorJsonReader),
+                          JsonReader.Property("message", JsonReader.String()),
+                          JsonReader.Property("comment_count", JsonReader.Int32()),
+                          (url, author, committer, message, commentCount) =>
+                              new Commit(url, author, committer, message, commentCount));
 
     static readonly IJsonReader<MergeBranchResponse> MergeBranchResponseJsonReader =
-        JsonReader.Object(
-            JsonReader.Property("url", from s in JsonReader.String() select new Uri(s)),
-            JsonReader.Property("sha", JsonReader.String()),
-            JsonReader.Property("commit", CommitJsonReader),
-            (url, sha, commit) => new MergeBranchResponse(url, sha, commit));
+        JsonReader.Object(JsonReader.Property("url", from s in JsonReader.String() select new Uri(s)),
+                          JsonReader.Property("sha", JsonReader.String()),
+                          JsonReader.Property("commit", CommitJsonReader),
+                          (url, sha, commit) => new MergeBranchResponse(url, sha, commit));
 
     [Params(10, 100, 1000, 10000)] public int ObjectCount { get; set; }
 
@@ -76,22 +72,19 @@ public class GithubApiBenchmark
         JsonSerializer.Deserialize<MergeBranchResponse[]>(this.jsonDataBytes)!;
 }
 
-public sealed record MergeBranchResponse(
-    [property: JsonPropertyName("url")] Uri Url,
-    [property: JsonPropertyName("sha")] string Sha,
-    [property: JsonPropertyName("commit")] Commit Commit
-);
+public sealed record MergeBranchResponse([property: JsonPropertyName("url")] Uri Url,
+                                         [property: JsonPropertyName("sha")] string Sha,
+                                         [property: JsonPropertyName("commit")] Commit Commit);
 
-public sealed record Commit(
-    [property: JsonPropertyName("url")] Uri Url,
-    [property: JsonPropertyName("author")] Author Author,
-    [property: JsonPropertyName("committer")] Author Committer,
-    [property: JsonPropertyName("message")] string Message,
-    [property: JsonPropertyName("comment_count")] int CommentCount
-);
+public sealed record Commit([property: JsonPropertyName("url")] Uri Url,
+                            [property: JsonPropertyName("author")] Author Author,
+                            [property: JsonPropertyName("committer")]
+                            Author Committer,
+                            [property: JsonPropertyName("message")]
+                            string Message,
+                            [property: JsonPropertyName("comment_count")]
+                            int CommentCount);
 
-public sealed record Author(
-    [property: JsonPropertyName("name")] string Name,
-    [property: JsonPropertyName("email")] string Email,
-    [property: JsonPropertyName("date")] DateTime Date
-);
+public sealed record Author([property: JsonPropertyName("name")] string Name,
+                            [property: JsonPropertyName("email")] string Email,
+                            [property: JsonPropertyName("date")] DateTime Date);

--- a/bench/GithubApiBenchmark.cs
+++ b/bench/GithubApiBenchmark.cs
@@ -1,0 +1,94 @@
+// Copyright (c) 2021 Atif Aziz.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using BenchmarkDotNet.Attributes;
+
+#pragma warning disable CA1050
+
+/// Benchmarks that are based on a partial response from the Github API.
+/// The benchmark is based on the response of merging a branch via the API.
+/// https://docs.github.com/en/rest/branches/branches#merge-a-branch.
+[MemoryDiagnoser]
+public class GithubApiBenchmark
+{
+    static readonly MergeBranchResponse TestData =
+        new(new Uri(
+                "https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e"),
+            "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+            new Commit(
+                new Uri(
+                    "https://api.github.com/repos/octocat/Hello-World/git/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e"),
+                new Author("Monalisa Octocat", "mona@github.com",
+                    DateTime.Parse("2011-04-14T16:00:49Z", CultureInfo.InvariantCulture)),
+                new Author("Monalisa Octocat", "mona@github.com",
+                    DateTime.Parse("2011-04-14T16:00:49Z", CultureInfo.InvariantCulture)),
+                "fix all the bugs",
+                12));
+
+    private static readonly IJsonReader<Author> AuthorJsonReader =
+        JsonReader.Object(
+            JsonReader.Property("name", JsonReader.String()),
+            JsonReader.Property("email", JsonReader.String()),
+            JsonReader.Property("date", JsonReader.DateTime()),
+            (name, email, date) => new Author(name, email, date));
+
+    private static readonly IJsonReader<Commit> CommitJsonReader =
+        JsonReader.Object(
+            JsonReader.Property("url", from s in JsonReader.String() select new Uri(s)),
+            JsonReader.Property("author", AuthorJsonReader),
+            JsonReader.Property("committer", AuthorJsonReader),
+            JsonReader.Property("message", JsonReader.String()),
+            JsonReader.Property("comment_count", JsonReader.Int32()),
+            (url, author, committer, message, commentCount) =>
+                new Commit(url, author, committer, message, commentCount));
+
+    static readonly IJsonReader<MergeBranchResponse> MergeBranchResponseJsonReader =
+        JsonReader.Object(
+            JsonReader.Property("url", from s in JsonReader.String() select new Uri(s)),
+            JsonReader.Property("sha", JsonReader.String()),
+            JsonReader.Property("commit", CommitJsonReader),
+            (url, sha, commit) => new MergeBranchResponse(url, sha, commit));
+
+    byte[] jsonDataBytes = Array.Empty<byte>();
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var json = JsonSerializer.Serialize(TestData);
+        this.jsonDataBytes = Encoding.UTF8.GetBytes(json);
+    }
+
+    [Benchmark]
+    public MergeBranchResponse JsonReaderBenchmark() =>
+        MergeBranchResponseJsonReader.Read(this.jsonDataBytes);
+
+    [Benchmark(Baseline = true)]
+    public MergeBranchResponse SystemTextJsonBenchmark() =>
+        JsonSerializer.Deserialize<MergeBranchResponse>(this.jsonDataBytes)!;
+}
+
+public sealed record MergeBranchResponse(
+    [property: JsonPropertyName("url")] Uri Url,
+    [property: JsonPropertyName("sha")] string Sha,
+    [property: JsonPropertyName("commit")] Commit Commit
+);
+
+public sealed record Commit(
+    [property: JsonPropertyName("url")] Uri Url,
+    [property: JsonPropertyName("author")] Author Author,
+    [property: JsonPropertyName("committer")] Author Committer,
+    [property: JsonPropertyName("message")] string Message,
+    [property: JsonPropertyName("comment_count")] int CommentCount
+);
+
+public sealed record Author(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("email")] string Email,
+    [property: JsonPropertyName("date")] DateTime Date
+);

--- a/bench/GithubApiBenchmark.cs
+++ b/bench/GithubApiBenchmark.cs
@@ -162,12 +162,9 @@ public sealed record MergeBranchResponse([property: JsonPropertyName("url")] Uri
 
 public sealed record Commit([property: JsonPropertyName("url")] Uri Url,
                             [property: JsonPropertyName("author")] Author Author,
-                            [property: JsonPropertyName("committer")]
-                            Author Committer,
-                            [property: JsonPropertyName("message")]
-                            string Message,
-                            [property: JsonPropertyName("comment_count")]
-                            int CommentCount);
+                            [property: JsonPropertyName("committer")] Author Committer,
+                            [property: JsonPropertyName("message")] string Message,
+                            [property: JsonPropertyName("comment_count")] int CommentCount);
 
 public sealed record Author([property: JsonPropertyName("name")] string Name,
                             [property: JsonPropertyName("email")] string Email,

--- a/bench/GithubApiBenchmark.cs
+++ b/bench/GithubApiBenchmark.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
@@ -18,18 +17,103 @@ using BenchmarkDotNet.Attributes;
 [MemoryDiagnoser]
 public class GithubApiBenchmark
 {
-    static readonly MergeBranchResponse TestData =
-        new(new Uri("https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e"),
-            "6dcb09b5b57875f334f61aebed695e2e4193db5e",
-            new Commit(new Uri("https://api.github.com/repos/octocat/Hello-World/git/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e"),
-                       new Author("Monalisa Octocat", "mona@github.com",
-                                  DateTime.Parse("2011-04-14T16:00:49Z",
-                                                 CultureInfo.InvariantCulture)),
-                       new Author("Monalisa Octocat", "mona@github.com",
-                                  DateTime.Parse("2011-04-14T16:00:49Z",
-                                                 CultureInfo.InvariantCulture)),
-                       "fix all the bugs",
-                       12));
+    const string TestData = /*lang=json,strict*/ """
+        {
+          "url": "https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+          "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+          "node_id": "MDY6Q29tbWl0NmRjYjA5YjViNTc4NzVmMzM0ZjYxYWViZWQ2OTVlMmU0MTkzZGI1ZQ==",
+          "html_url": "https://github.com/octocat/Hello-World/commit/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+          "comments_url": "https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e/comments",
+          "commit": {
+            "url": "https://api.github.com/repos/octocat/Hello-World/git/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+            "author": {
+              "name": "Monalisa Octocat",
+              "email": "mona@github.com",
+              "date": "2011-04-14T16:00:49Z"
+            },
+            "committer": {
+              "name": "Monalisa Octocat",
+              "email": "mona@github.com",
+              "date": "2011-04-14T16:00:49Z"
+            },
+            "message": "Fix all the bugs",
+            "tree": {
+              "url": "https://api.github.com/repos/octocat/Hello-World/tree/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+              "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e"
+            },
+            "comment_count": 0,
+            "verification": {
+              "verified": false,
+              "reason": "unsigned",
+              "signature": null,
+              "payload": null
+            }
+          },
+          "author": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "committer": {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+          },
+          "parents": [
+            {
+              "url": "https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+              "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e"
+            }
+          ],
+          "stats": {
+            "additions": 104,
+            "deletions": 4,
+            "total": 108
+          },
+          "files": [
+            {
+              "filename": "file1.txt",
+              "additions": 10,
+              "deletions": 2,
+              "changes": 12,
+              "status": "modified",
+              "raw_url": "https://github.com/octocat/Hello-World/raw/7ca483543807a51b6079e54ac4cc392bc29ae284/file1.txt",
+              "blob_url": "https://github.com/octocat/Hello-World/blob/7ca483543807a51b6079e54ac4cc392bc29ae284/file1.txt",
+              "patch": "@@ -29,7 +29,7 @@\n....."
+            }
+          ]
+        }
+        """;
 
     private static readonly IJsonReader<Author> AuthorJsonReader =
         JsonReader.Object(JsonReader.Property("name", JsonReader.String()),
@@ -59,7 +143,7 @@ public class GithubApiBenchmark
     [GlobalSetup]
     public void Setup()
     {
-        var json = JsonSerializer.Serialize(Enumerable.Repeat(TestData, ObjectCount));
+        var json = $"[{string.Join(",", Enumerable.Repeat(TestData, ObjectCount))}]";
         this.jsonDataBytes = Encoding.UTF8.GetBytes(json);
     }
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -83,9 +83,7 @@ In another configuration, we benchmark the worst-case scenario performance of
 | SystemTextJsonBenchmark | NativeAOT 7.0 | 10000       | MultiPolygon | 127,045.45 μs | 2,512.918 μs | 3,761.218 μs |  1.00 |    0.00 | 6500.0000 | 3000.0000 |  750.0000 | 37510.46 KB |        1.00 |
 
 When benchmarking deserialization a subset of an example payload from the
-[GitHub REST
-API](https://docs.github.com/en/rest/branches/branches#merge-a-branch), we
-measure the following:
+[GitHub REST API (Merge a branch)], we measure the following:
 
     BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.819)
     Intel Core i7-1065G7 CPU 1.30GHz, 1 CPU, 8 logical and 4 physical cores
@@ -125,3 +123,5 @@ measure the following:
 | SystemTextJsonBenchmark | .NET 7.0      | 10000       | 138,900.25 us | 5,720.888 us | 16,778.376 us | 133,623.48 us |  0.99 |    0.17 | 2500.0000 | 1250.0000 | 250.0000 | 16359.59 KB |        1.00 |
 | JsonReaderBenchmark     | NativeAOT 7.0 | 10000       | 130,683.21 us | 4,577.537 us | 13,207.241 us | 126,413.93 us |  0.93 |    0.15 | 2000.0000 | 1000.0000 | 250.0000 | 11194.13 KB |        0.68 |
 | SystemTextJsonBenchmark | NativeAOT 7.0 | 10000       | 142,635.96 us | 6,687.071 us | 18,970.107 us | 135,900.80 us |  1.00 |    0.00 | 2500.0000 | 1250.0000 | 250.0000 |  16360.5 KB |        1.00 |
+
+  [GitHub REST API]: https://docs.github.com/en/rest/branches/branches#merge-a-branch

--- a/bench/README.md
+++ b/bench/README.md
@@ -82,7 +82,10 @@ In another configuration, we benchmark the worst-case scenario performance of
 | JsonReaderBenchmark     | NativeAOT 7.0 | 10000       | MultiPolygon | 123,240.28 μs | 2,443.043 μs | 2,508.826 μs |  0.97 |    0.04 | 3600.0000 | 1400.0000 |  400.0000 | 19945.28 KB |        0.53 |
 | SystemTextJsonBenchmark | NativeAOT 7.0 | 10000       | MultiPolygon | 127,045.45 μs | 2,512.918 μs | 3,761.218 μs |  1.00 |    0.00 | 6500.0000 | 3000.0000 |  750.0000 | 37510.46 KB |        1.00 |
 
-When benchmarking deserialization a subset of an example payload from the [GitHub REST API](https://docs.github.com/en/rest/branches/branches#merge-a-branch), we measure the following:
+When benchmarking deserialization a subset of an example payload from the
+[GitHub REST
+API](https://docs.github.com/en/rest/branches/branches#merge-a-branch), we
+measure the following:
 
     BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.819)
     Intel Core i7-1065G7 CPU 1.30GHz, 1 CPU, 8 logical and 4 physical cores

--- a/bench/README.md
+++ b/bench/README.md
@@ -81,3 +81,44 @@ In another configuration, we benchmark the worst-case scenario performance of
 | SystemTextJsonBenchmark | .NET 7.0      | 10000       | MultiPolygon | 127,485.37 μs | 2,488.375 μs | 4,292.325 μs |  1.00 |    0.04 | 6500.0000 | 3000.0000 |  750.0000 |  37511.3 KB |        1.00 |
 | JsonReaderBenchmark     | NativeAOT 7.0 | 10000       | MultiPolygon | 123,240.28 μs | 2,443.043 μs | 2,508.826 μs |  0.97 |    0.04 | 3600.0000 | 1400.0000 |  400.0000 | 19945.28 KB |        0.53 |
 | SystemTextJsonBenchmark | NativeAOT 7.0 | 10000       | MultiPolygon | 127,045.45 μs | 2,512.918 μs | 3,761.218 μs |  1.00 |    0.00 | 6500.0000 | 3000.0000 |  750.0000 | 37510.46 KB |        1.00 |
+
+When benchmarking deserialization a subset of an example payload from the [GitHub REST API](https://docs.github.com/en/rest/branches/branches#merge-a-branch), we measure the following:
+
+    BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.819)
+    Intel Core i7-1065G7 CPU 1.30GHz, 1 CPU, 8 logical and 4 physical cores
+    .NET SDK=7.0.100
+      [Host]     : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
+      Job-QOSTER : .NET 6.0.11 (6.0.1122.52304), X64 RyuJIT AVX2
+      Job-NCTTVP : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
+      Job-YSQJJI : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
+
+
+| Method                  | Runtime       | ObjectCount |          Mean |        Error |        StdDev |        Median | Ratio | RatioSD |      Gen0 |      Gen1 |     Gen2 |   Allocated | Alloc Ratio |
+| ----------------------- | ------------- | ----------- | ------------: | -----------: | ------------: | ------------: | ----: | ------: | --------: | --------: | -------: | ----------: | ----------: |
+| JsonReaderBenchmark     | .NET 6.0      | 10          |     202.34 us |    20.552 us |     60.598 us |     190.91 us |  1.99 |    0.64 |    2.4414 |         - |        - |    11.41 KB |        0.67 |
+| SystemTextJsonBenchmark | .NET 6.0      | 10          |     117.39 us |     4.646 us |     13.553 us |     113.90 us |  1.13 |    0.17 |    4.1504 |    0.2441 |        - |    17.25 KB |        1.02 |
+| JsonReaderBenchmark     | .NET 7.0      | 10          |     112.36 us |     3.832 us |     11.118 us |     110.38 us |  1.08 |    0.17 |    2.6855 |         - |        - |    11.41 KB |        0.67 |
+| SystemTextJsonBenchmark | .NET 7.0      | 10          |      98.76 us |     2.991 us |      8.773 us |      96.94 us |  0.95 |    0.14 |    4.1504 |         - |        - |    16.97 KB |        1.00 |
+| JsonReaderBenchmark     | NativeAOT 7.0 | 10          |     168.08 us |    25.396 us |     74.880 us |     132.77 us |  1.63 |    0.68 |    2.4414 |         - |        - |    11.41 KB |        0.67 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 | 10          |     105.50 us |     4.485 us |     12.797 us |     104.44 us |  1.00 |    0.00 |    4.1504 |         - |        - |    16.97 KB |        1.00 |
+|                         |               |             |               |              |               |               |       |         |           |           |          |             |             |
+| JsonReaderBenchmark     | .NET 6.0      | 100         |   1,240.36 us |    36.970 us |    106.667 us |   1,196.85 us |  1.08 |    0.15 |   25.3906 |    7.8125 |        - |   111.67 KB |        0.69 |
+| SystemTextJsonBenchmark | .NET 6.0      | 100         |   1,144.78 us |    37.520 us |    108.255 us |   1,109.01 us |  1.00 |    0.13 |   37.1094 |   11.7188 |        - |   164.66 KB |        1.02 |
+| JsonReaderBenchmark     | .NET 7.0      | 100         |   1,185.21 us |    40.298 us |    114.973 us |   1,145.08 us |  1.04 |    0.17 |   25.3906 |    7.8125 |        - |   111.67 KB |        0.69 |
+| SystemTextJsonBenchmark | .NET 7.0      | 100         |   1,109.15 us |    35.183 us |    102.073 us |   1,068.34 us |  0.97 |    0.14 |   35.1563 |    9.7656 |        - |   161.56 KB |        1.00 |
+| JsonReaderBenchmark     | NativeAOT 7.0 | 100         |   1,114.53 us |    29.102 us |     80.156 us |   1,083.46 us |  0.97 |    0.13 |   23.4375 |    7.8125 |        - |   111.67 KB |        0.69 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 | 100         |   1,159.15 us |    52.550 us |    153.290 us |   1,103.81 us |  1.00 |    0.00 |   33.2031 |    9.7656 |        - |   161.56 KB |        1.00 |
+|                         |               |             |               |              |               |               |       |         |           |           |          |             |             |
+| JsonReaderBenchmark     | .NET 6.0      | 1000        |  13,449.47 us |   462.489 us |  1,341.763 us |  13,214.85 us |  0.95 |    0.15 |  171.8750 |   78.1250 |        - |  1110.12 KB |        0.70 |
+| SystemTextJsonBenchmark | .NET 6.0      | 1000        |  15,895.95 us |   942.387 us |  2,748.988 us |  15,849.49 us |  1.13 |    0.27 |  250.0000 |  125.0000 |        - |  1619.96 KB |        1.02 |
+| JsonReaderBenchmark     | .NET 7.0      | 1000        |  15,377.16 us |   479.259 us |  1,320.019 us |  15,327.51 us |  1.08 |    0.17 |  171.8750 |  156.2500 |        - |  1110.12 KB |        0.70 |
+| SystemTextJsonBenchmark | .NET 7.0      | 1000        |  14,739.72 us |   508.641 us |  1,459.387 us |  14,526.50 us |  1.04 |    0.15 |  250.0000 |  234.3750 |        - |  1588.75 KB |        1.00 |
+| JsonReaderBenchmark     | NativeAOT 7.0 | 1000        |  18,554.27 us | 1,701.470 us |  4,963.269 us |  16,851.99 us |  1.32 |    0.40 |  171.8750 |  156.2500 |        - |  1110.12 KB |        0.70 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 | 1000        |  14,366.94 us |   629.301 us |  1,835.700 us |  13,511.67 us |  1.00 |    0.00 |  250.0000 |  218.7500 |        - |  1588.76 KB |        1.00 |
+|                         |               |             |               |              |               |               |       |         |           |           |          |             |             |
+| JsonReaderBenchmark     | .NET 6.0      | 10000       | 168,778.99 us | 6,104.380 us | 17,903.090 us | 160,740.15 us |  1.20 |    0.19 | 2000.0000 | 1000.0000 | 250.0000 | 11194.13 KB |        0.68 |
+| SystemTextJsonBenchmark | .NET 6.0      | 10000       | 168,772.76 us | 6,891.284 us | 20,102.200 us | 159,809.92 us |  1.19 |    0.21 | 2500.0000 | 1000.0000 |        - | 16672.09 KB |        1.02 |
+| JsonReaderBenchmark     | .NET 7.0      | 10000       | 131,258.49 us | 3,662.383 us | 10,148.446 us | 129,675.98 us |  0.93 |    0.12 | 2000.0000 | 1000.0000 | 250.0000 | 11194.13 KB |        0.68 |
+| SystemTextJsonBenchmark | .NET 7.0      | 10000       | 138,900.25 us | 5,720.888 us | 16,778.376 us | 133,623.48 us |  0.99 |    0.17 | 2500.0000 | 1250.0000 | 250.0000 | 16359.59 KB |        1.00 |
+| JsonReaderBenchmark     | NativeAOT 7.0 | 10000       | 130,683.21 us | 4,577.537 us | 13,207.241 us | 126,413.93 us |  0.93 |    0.15 | 2000.0000 | 1000.0000 | 250.0000 | 11194.13 KB |        0.68 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 | 10000       | 142,635.96 us | 6,687.071 us | 18,970.107 us | 135,900.80 us |  1.00 |    0.00 | 2500.0000 | 1250.0000 | 250.0000 |  16360.5 KB |        1.00 |


### PR DESCRIPTION
This PR is a follow-up of #5 and adds another benchmark that compares Jacob with `System.Text.Json`. The benchmark tests deserializing JSON data which is based on a [response from the Github API](https://docs.github.com/en/rest/branches/branches#merge-a-branch). The benchmark only makes use of a subset of the response schema, attempting to achieve a balance between different types such as `string`, `Uri`, `DateTime` and `int`. To get a more complete picture of the performance for different JSON document sizes, the benchmark exercises a scenario where the API returns an array of response objects.

Also, as opposed to the `GeoJsonBenchmark`s, we do not need any transformation of the return data when using `System.Text.Json`. Instead, we can deserialize data directly into the "resulting" `record`s, which one would assume is `System.Text.Json`s main use case. When running the benchmark the results are as follows:

```
BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.819)
Intel Core i7-1065G7 CPU 1.30GHz, 1 CPU, 8 logical and 4 physical cores
.NET SDK=7.0.100
  [Host]     : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
  Job-QOSTER : .NET 6.0.11 (6.0.1122.52304), X64 RyuJIT AVX2
  Job-NCTTVP : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
  Job-YSQJJI : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2


|                  Method |       Runtime | ObjectCount |          Mean |        Error |        StdDev |        Median | Ratio | RatioSD |      Gen0 |      Gen1 |     Gen2 |   Allocated | Alloc Ratio |
|------------------------ |-------------- |------------ |--------------:|-------------:|--------------:|--------------:|------:|--------:|----------:|----------:|---------:|------------:|------------:|
|     JsonReaderBenchmark |      .NET 6.0 |          10 |     202.34 us |    20.552 us |     60.598 us |     190.91 us |  1.99 |    0.64 |    2.4414 |         - |        - |    11.41 KB |        0.67 |
| SystemTextJsonBenchmark |      .NET 6.0 |          10 |     117.39 us |     4.646 us |     13.553 us |     113.90 us |  1.13 |    0.17 |    4.1504 |    0.2441 |        - |    17.25 KB |        1.02 |
|     JsonReaderBenchmark |      .NET 7.0 |          10 |     112.36 us |     3.832 us |     11.118 us |     110.38 us |  1.08 |    0.17 |    2.6855 |         - |        - |    11.41 KB |        0.67 |
| SystemTextJsonBenchmark |      .NET 7.0 |          10 |      98.76 us |     2.991 us |      8.773 us |      96.94 us |  0.95 |    0.14 |    4.1504 |         - |        - |    16.97 KB |        1.00 |
|     JsonReaderBenchmark | NativeAOT 7.0 |          10 |     168.08 us |    25.396 us |     74.880 us |     132.77 us |  1.63 |    0.68 |    2.4414 |         - |        - |    11.41 KB |        0.67 |
| SystemTextJsonBenchmark | NativeAOT 7.0 |          10 |     105.50 us |     4.485 us |     12.797 us |     104.44 us |  1.00 |    0.00 |    4.1504 |         - |        - |    16.97 KB |        1.00 |
|                         |               |             |               |              |               |               |       |         |           |           |          |             |             |
|     JsonReaderBenchmark |      .NET 6.0 |         100 |   1,240.36 us |    36.970 us |    106.667 us |   1,196.85 us |  1.08 |    0.15 |   25.3906 |    7.8125 |        - |   111.67 KB |        0.69 |
| SystemTextJsonBenchmark |      .NET 6.0 |         100 |   1,144.78 us |    37.520 us |    108.255 us |   1,109.01 us |  1.00 |    0.13 |   37.1094 |   11.7188 |        - |   164.66 KB |        1.02 |
|     JsonReaderBenchmark |      .NET 7.0 |         100 |   1,185.21 us |    40.298 us |    114.973 us |   1,145.08 us |  1.04 |    0.17 |   25.3906 |    7.8125 |        - |   111.67 KB |        0.69 |
| SystemTextJsonBenchmark |      .NET 7.0 |         100 |   1,109.15 us |    35.183 us |    102.073 us |   1,068.34 us |  0.97 |    0.14 |   35.1563 |    9.7656 |        - |   161.56 KB |        1.00 |
|     JsonReaderBenchmark | NativeAOT 7.0 |         100 |   1,114.53 us |    29.102 us |     80.156 us |   1,083.46 us |  0.97 |    0.13 |   23.4375 |    7.8125 |        - |   111.67 KB |        0.69 |
| SystemTextJsonBenchmark | NativeAOT 7.0 |         100 |   1,159.15 us |    52.550 us |    153.290 us |   1,103.81 us |  1.00 |    0.00 |   33.2031 |    9.7656 |        - |   161.56 KB |        1.00 |
|                         |               |             |               |              |               |               |       |         |           |           |          |             |             |
|     JsonReaderBenchmark |      .NET 6.0 |        1000 |  13,449.47 us |   462.489 us |  1,341.763 us |  13,214.85 us |  0.95 |    0.15 |  171.8750 |   78.1250 |        - |  1110.12 KB |        0.70 |
| SystemTextJsonBenchmark |      .NET 6.0 |        1000 |  15,895.95 us |   942.387 us |  2,748.988 us |  15,849.49 us |  1.13 |    0.27 |  250.0000 |  125.0000 |        - |  1619.96 KB |        1.02 |
|     JsonReaderBenchmark |      .NET 7.0 |        1000 |  15,377.16 us |   479.259 us |  1,320.019 us |  15,327.51 us |  1.08 |    0.17 |  171.8750 |  156.2500 |        - |  1110.12 KB |        0.70 |
| SystemTextJsonBenchmark |      .NET 7.0 |        1000 |  14,739.72 us |   508.641 us |  1,459.387 us |  14,526.50 us |  1.04 |    0.15 |  250.0000 |  234.3750 |        - |  1588.75 KB |        1.00 |
|     JsonReaderBenchmark | NativeAOT 7.0 |        1000 |  18,554.27 us | 1,701.470 us |  4,963.269 us |  16,851.99 us |  1.32 |    0.40 |  171.8750 |  156.2500 |        - |  1110.12 KB |        0.70 |
| SystemTextJsonBenchmark | NativeAOT 7.0 |        1000 |  14,366.94 us |   629.301 us |  1,835.700 us |  13,511.67 us |  1.00 |    0.00 |  250.0000 |  218.7500 |        - |  1588.76 KB |        1.00 |
|                         |               |             |               |              |               |               |       |         |           |           |          |             |             |
|     JsonReaderBenchmark |      .NET 6.0 |       10000 | 168,778.99 us | 6,104.380 us | 17,903.090 us | 160,740.15 us |  1.20 |    0.19 | 2000.0000 | 1000.0000 | 250.0000 | 11194.13 KB |        0.68 |
| SystemTextJsonBenchmark |      .NET 6.0 |       10000 | 168,772.76 us | 6,891.284 us | 20,102.200 us | 159,809.92 us |  1.19 |    0.21 | 2500.0000 | 1000.0000 |        - | 16672.09 KB |        1.02 |
|     JsonReaderBenchmark |      .NET 7.0 |       10000 | 131,258.49 us | 3,662.383 us | 10,148.446 us | 129,675.98 us |  0.93 |    0.12 | 2000.0000 | 1000.0000 | 250.0000 | 11194.13 KB |        0.68 |
| SystemTextJsonBenchmark |      .NET 7.0 |       10000 | 138,900.25 us | 5,720.888 us | 16,778.376 us | 133,623.48 us |  0.99 |    0.17 | 2500.0000 | 1250.0000 | 250.0000 | 16359.59 KB |        1.00 |
|     JsonReaderBenchmark | NativeAOT 7.0 |       10000 | 130,683.21 us | 4,577.537 us | 13,207.241 us | 126,413.93 us |  0.93 |    0.15 | 2000.0000 | 1000.0000 | 250.0000 | 11194.13 KB |        0.68 |
| SystemTextJsonBenchmark | NativeAOT 7.0 |       10000 | 142,635.96 us | 6,687.071 us | 18,970.107 us | 135,900.80 us |  1.00 |    0.00 | 2500.0000 | 1250.0000 | 250.0000 |  16360.5 KB |        1.00 |
```