### PR TITLE
Use strict JSON in string literals

### DIFF
--- a/bench/GeoJsonBenchmarks.cs
+++ b/bench/GeoJsonBenchmarks.cs
@@ -20,80 +20,27 @@ using System.Collections.Generic;
 [MemoryDiagnoser]
 public class GeoJsonBenchmarks
 {
-    const string PointJson = @"
-    {
-        type: 'Point',
-        coordinates: [100.0, 0.0]
-    }";
+    const string PointJson = /*lang=json*/ """
+        {
+            "type": "Point",
+            "coordinates": [100.0, 0.0]
+        }
+        """;
 
-    const string LineStringJson = @"
-    {
-        type: 'LineString',
-        coordinates: [
-            [100.0, 0.0],
-            [101.0, 1.0]
-        ]
-    }";
-
-    const string PolygonJson = @"
-    {
-        type: 'Polygon',
-        coordinates: [
-            [
-                [100.0, 0.0],
-                [101.0, 0.0],
-                [101.0, 1.0],
-                [100.0, 1.0],
-                [100.0, 0.0]
-            ],
-            [
-                [100.8, 0.8],
-                [100.8, 0.2],
-                [100.2, 0.2],
-                [100.2, 0.8],
-                [100.8, 0.8]
-            ]
-        ]
-    }";
-
-    const string MultiPointJson = @"
-    {
-        type: 'MultiPoint',
-        coordinates: [
-            [100.0, 0.0],
-            [101.0, 1.0]
-        ]
-    }";
-
-    const string MultiLineStringJson = @"
-    {
-        type: 'MultiLineString',
-        coordinates: [
-            [
+    const string LineStringJson = /*lang=json*/ """
+        {
+            "type": "LineString",
+            "coordinates": [
                 [100.0, 0.0],
                 [101.0, 1.0]
-            ],
-            [
-                [102.0, 2.0],
-                [103.0, 3.0]
             ]
-        ]
-    }";
+        }
+        """;
 
-    const string MultiPolygonJson = @"
-    {
-        type: 'MultiPolygon',
-        coordinates: [
-            [
-                [
-                    [102.0, 2.0],
-                    [103.0, 2.0],
-                    [103.0, 3.0],
-                    [102.0, 3.0],
-                    [102.0, 2.0]
-                ]
-            ],
-            [
+    const string PolygonJson = /*lang=json*/ """
+        {
+            "type": "Polygon",
+            "coordinates": [
                 [
                     [100.0, 0.0],
                     [101.0, 0.0],
@@ -102,30 +49,90 @@ public class GeoJsonBenchmarks
                     [100.0, 0.0]
                 ],
                 [
-                    [100.2, 0.2],
-                    [100.2, 0.8],
                     [100.8, 0.8],
                     [100.8, 0.2],
-                    [100.2, 0.2]
+                    [100.2, 0.2],
+                    [100.2, 0.8],
+                    [100.8, 0.8]
                 ]
             ]
-        ]
-    }";
+        }
+        """;
 
-    const string GeometryCollectionJson = @"
-    {
-        type: 'GeometryCollection',
-        geometries: [{
-            type: 'Point',
-            coordinates: [100.0, 0.0]
-        }, {
-            type: 'LineString',
-            coordinates: [
-                [101.0, 0.0],
-                [102.0, 1.0]
+    const string MultiPointJson = /*lang=json*/ """
+        {
+            "type": "MultiPoint",
+            "coordinates": [
+                [100.0, 0.0],
+                [101.0, 1.0]
             ]
-        }]
-    }";
+        }
+        """;
+
+    const string MultiLineStringJson = /*lang=json*/ """
+        {
+            "type": "MultiLineString",
+            "coordinates": [
+                [
+                    [100.0, 0.0],
+                    [101.0, 1.0]
+                ],
+                [
+                    [102.0, 2.0],
+                    [103.0, 3.0]
+                ]
+            ]
+        }
+        """;
+
+    const string MultiPolygonJson = /*lang=json*/ """
+        {
+            "type": "MultiPolygon",
+            "coordinates": [
+                [
+                    [
+                        [102.0, 2.0],
+                        [103.0, 2.0],
+                        [103.0, 3.0],
+                        [102.0, 3.0],
+                        [102.0, 2.0]
+                    ]
+                ],
+                [
+                    [
+                        [100.0, 0.0],
+                        [101.0, 0.0],
+                        [101.0, 1.0],
+                        [100.0, 1.0],
+                        [100.0, 0.0]
+                    ],
+                    [
+                        [100.2, 0.2],
+                        [100.2, 0.8],
+                        [100.8, 0.8],
+                        [100.8, 0.2],
+                        [100.2, 0.2]
+                    ]
+                ]
+            ]
+        }
+        """;
+
+    const string GeometryCollectionJson = /*lang=json*/ """
+        {
+            "type": "GeometryCollection",
+            "geometries": [{
+                "type": "Point",
+                "coordinates": [100.0, 0.0]
+            }, {
+                "type": "LineString",
+                "coordinates": [
+                    [101.0, 0.0],
+                    [102.0, 1.0]
+                ]
+            }]
+        }
+        """;
 
     public enum SampleSetId
     {
@@ -157,7 +164,7 @@ public class GeoJsonBenchmarks
         _ = json.Append(string.Join(',', Jsons[SampleSet].Repeat().Take(ObjectCount)));
         _ = json.Append(']');
 
-        this.jsonDataBytes = Encoding.UTF8.GetBytes(Strictify(json.ToString()));
+        this.jsonDataBytes = Encoding.UTF8.GetBytes(json.ToString());
     }
 
     [Benchmark]
@@ -171,9 +178,6 @@ public class GeoJsonBenchmarks
     {
         return SystemTextGeoJsonReader.Read(this.jsonDataBytes);
     }
-
-    static string Strictify(string json) =>
-        Newtonsoft.Json.Linq.JToken.Parse(json).ToString(Newtonsoft.Json.Formatting.None);
 
     static class SystemTextGeoJsonReader
     {

--- a/bench/Jacob.Benchmarks.csproj
+++ b/bench/Jacob.Benchmarks.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.2" />
     <PackageReference Include="morelinq" Version="3.3.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\eg\Jacob.Examples.csproj" />

--- a/tests/Jacob.Tests.csproj
+++ b/tests/Jacob.Tests.csproj
@@ -13,7 +13,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
The JSON in string literals (especially unit tests and benchmarks) was not strictly formatted according to RFC 8259. For example, object member names were unquoted, strings could be single-quotes and so on. Then Json.NET (which [allows that relaxed format](https://github.com/JamesNK/Newtonsoft.Json/issues/646#issuecomment-356194475)) was being used to convert the non-conforming JSON to strict JSON because `Utf8JsonReader` only work with the latter. Using the simpler and more relaxed JSON didn't require escaping all the double quotation marks. This PR removes the need for Json.NET by putting strict JSON in C# raw string literals, which don't require escaping the double quotation marks. All the JSON in C# strings is tagged with `/*lang=json*/` ([`JSON002`](https://github.com/dotnet/roslyn/issues/48530)).