### PR TITLE
Use last value read for a property

### DIFF
--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -374,7 +374,7 @@ public static partial class JsonReader
                                                       ref (bool, TValue) value,
                                                       ref string? error)
                 {
-                    if (value is (true, _) || !property.IsMatch(ref reader))
+                    if (!property.IsMatch(ref reader))
                         return false;
 
                     _ = reader.Read();

--- a/tests/JsonReaderTests.cs
+++ b/tests/JsonReaderTests.cs
@@ -540,21 +540,21 @@ public class JsonReaderTests
                           ValueTuple.Create);
 
     [Theory]
-    [InlineData(  0, "foobar", /*lang=json*/ """
-                               { "str": "foobar" }
-                               """)]
-    [InlineData( 42, "foobar", /*lang=json*/ """
-                               { "num": 42, "str": "foobar" }
-                               """)]
-    [InlineData( 42, "foobar", /*lang=json*/ """
-                               { "str": "foobar", "num": 42 }
-                               """)]
-    [InlineData(-42, "FOOBAR", /*lang=json*/ """
-                               { "str": "FOOBAR", "num": -42, "str": "foobar", "num": 42 }
-                               """)]
-    [InlineData( 42, "foobar", /*lang=json*/ """
-                               { "nums": [1, 2, 3], "str": "foobar", "num": 42, "obj": {} }
-                               """)]
+    [InlineData( 0, "foobar", /*lang=json*/ """
+                              { "str": "foobar" }
+                              """)]
+    [InlineData(42, "foobar", /*lang=json*/ """
+                              { "num": 42, "str": "foobar" }
+                              """)]
+    [InlineData(42, "foobar", /*lang=json*/ """
+                              { "str": "foobar", "num": 42 }
+                              """)]
+    [InlineData(42, "foobar", /*lang=json*/ """
+                              { "str": "FOOBAR", "num": -42, "str": "foobar", "num": 42 }
+                              """)]
+    [InlineData(42, "foobar", /*lang=json*/ """
+                              { "nums": [1, 2, 3], "str": "foobar", "num": 42, "obj": {} }
+                              """)]
     public void Object_With_Valid_Input(int expectedNum, string expectedStr, string json)
     {
         var (num, str) = ObjectReader.Read(json);


### PR DESCRIPTION
This PR updates the object reading to use the latest value for a property in case a JSON object has a property listed multiple times.

Suppose the following code:

```c#
var reader =
    JsonReader.Object(JsonReader.Property("num", JsonReader.Int32(), (true, 0)),
                      JsonReader.Property("str", JsonReader.String()),
                      (num, str) => new { Num = num, Str = str });

const string json = """
    {
        "str": "FOOBAR",
        "num": -42,
        "str": "foobar",
        "num": 42
    }
    """;

Console.WriteLine(reader.Read(json));
```

Before this PR, it would print:

    { Num = -42, Str = FOOBAR }

After this PR, it will be:

    { Num = 42, Str = foobar }
