### PR TITLE
Use complete response from GitHub API benchmark

### DIFF
--- a/bench/GithubApiBenchmark.cs
+++ b/bench/GithubApiBenchmark.cs
@@ -208,7 +208,7 @@ public class GithubApiBenchmark
                               new MergeBranchResponse(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11));
 
     static IJsonReader<T?> Nullable<T>(IJsonReader<T> reader, T? @null) =>
-        JsonReader.Either(from v in JsonReader.Null(@null) select v, from v in reader select v);
+        JsonReader.Either(JsonReader.Null(@null), from v in reader select v);
 
     static IJsonReader<ImmutableArray<T>> ImmutableArrayReader<T>(IJsonReader<T> reader) =>
         from v in JsonReader.Array(reader) select v.ToImmutableArray();

--- a/bench/GithubApiBenchmark.cs
+++ b/bench/GithubApiBenchmark.cs
@@ -125,14 +125,20 @@ public class GithubApiBenchmark
                           JsonReader.Property("date", JsonReader.DateTime()),
                           (name, email, date) => new Author(name, email, date));
 
+    private static readonly IJsonReader<Tree> TreeReader =
+        JsonReader.Object(JsonReader.Property("url", UriReader),
+                          JsonReader.Property("sha", JsonReader.String()),
+                          (url, sha) => new Tree(url, sha));
+
     private static readonly IJsonReader<Commit> CommitJsonReader =
         JsonReader.Object(JsonReader.Property("url", UriReader),
                           JsonReader.Property("author", AuthorJsonReader),
                           JsonReader.Property("committer", AuthorJsonReader),
                           JsonReader.Property("message", JsonReader.String()),
+                          JsonReader.Property("tree", TreeReader),
                           JsonReader.Property("comment_count", JsonReader.Int32()),
-                          (url, author, committer, message, commentCount) =>
-                              new Commit(url, author, committer, message, commentCount));
+                          (url, author, committer, message, tree, commentCount) =>
+                              new Commit(url, author, committer, message, tree, commentCount));
 
     static readonly IJsonReader<MergeBranchResponse> MergeBranchResponseJsonReader =
         JsonReader.Object(JsonReader.Property("url", UriReader),
@@ -168,8 +174,12 @@ public sealed record Commit([property: JsonPropertyName("url")] Uri Url,
                             [property: JsonPropertyName("author")] Author Author,
                             [property: JsonPropertyName("committer")] Author Committer,
                             [property: JsonPropertyName("message")] string Message,
+                            [property: JsonPropertyName("tree")] Tree Tree,
                             [property: JsonPropertyName("comment_count")] int CommentCount);
 
 public sealed record Author([property: JsonPropertyName("name")] string Name,
                             [property: JsonPropertyName("email")] string Email,
                             [property: JsonPropertyName("date")] DateTime Date);
+
+public sealed record Tree([property: JsonPropertyName("url")] Uri Url,
+                          [property: JsonPropertyName("sha")] string Sha);

--- a/bench/GithubApiBenchmark.cs
+++ b/bench/GithubApiBenchmark.cs
@@ -120,11 +120,11 @@ public class GithubApiBenchmark
         from s in JsonReader.String()
         select new Uri(s);
 
-    static readonly IJsonReader<CommitAuthor> CommitAuthorJsonReader =
+    static readonly IJsonReader<CommitUser> CommitUserJsonReader =
         JsonReader.Object(JsonReader.Property("name", JsonReader.String()),
                           JsonReader.Property("email", JsonReader.String()),
                           JsonReader.Property("date", JsonReader.DateTime()),
-                          (p1, p2, p3) => new CommitAuthor(p1, p2, p3));
+                          (p1, p2, p3) => new CommitUser(p1, p2, p3));
 
     static readonly IJsonReader<Tree> TreeJsonReader =
         JsonReader.Object(JsonReader.Property("url", UriReader),
@@ -140,8 +140,8 @@ public class GithubApiBenchmark
 
     static readonly IJsonReader<Commit> CommitJsonReader =
         JsonReader.Object(JsonReader.Property("url", UriReader),
-                          JsonReader.Property("author", CommitAuthorJsonReader),
-                          JsonReader.Property("committer", CommitAuthorJsonReader),
+                          JsonReader.Property("author", CommitUserJsonReader),
+                          JsonReader.Property("committer", CommitUserJsonReader),
                           JsonReader.Property("message", JsonReader.String()),
                           JsonReader.Property("tree", TreeJsonReader),
                           JsonReader.Property("comment_count", JsonReader.Int32()),
@@ -149,7 +149,7 @@ public class GithubApiBenchmark
                           (p1, p2, p3, p4, p5, p6, p7) =>
                               new Commit(p1, p2, p3, p4, p5, p6, p7));
 
-    static readonly IJsonReader<Author> AuthorJsonReader =
+    static readonly IJsonReader<GitHubUser> GitHubUserJsonReader =
         JsonReader.Object(JsonReader.Property("login", JsonReader.String()),
                           JsonReader.Property("id", JsonReader.Int32()),
                           JsonReader.Property("node_id", JsonReader.String()),
@@ -172,7 +172,7 @@ public class GithubApiBenchmark
                            * JsonReader.Property("site_admin", JsonReader.Boolean()
                            */
                           (p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16) =>
-                              new Author(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16));
+                              new GitHubUser(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16));
 
     static readonly IJsonReader<Stats> StatsJsonReader =
         JsonReader.Object(JsonReader.Property("additions", JsonReader.Int32()),
@@ -199,8 +199,8 @@ public class GithubApiBenchmark
                           JsonReader.Property("html_url", UriReader),
                           JsonReader.Property("comments_url", UriReader),
                           JsonReader.Property("commit", CommitJsonReader),
-                          JsonReader.Property("author", AuthorJsonReader),
-                          JsonReader.Property("committer", AuthorJsonReader),
+                          JsonReader.Property("author", GitHubUserJsonReader),
+                          JsonReader.Property("committer", GitHubUserJsonReader),
                           JsonReader.Property("parents", ImmutableArrayReader(TreeJsonReader)),
                           JsonReader.Property("stats", StatsJsonReader),
                           JsonReader.Property("files", ImmutableArrayReader(FileJsonReader)),
@@ -239,23 +239,23 @@ public sealed record MergeBranchResponse([property: JsonPropertyName("url")] Uri
                                          [property: JsonPropertyName("html_url")] Uri HtmlUrl,
                                          [property: JsonPropertyName("comments_url")] Uri CommentsUrl,
                                          [property: JsonPropertyName("commit")] Commit Commit,
-                                         [property: JsonPropertyName("author")] Author Author,
-                                         [property: JsonPropertyName("committer")] Author Committer,
+                                         [property: JsonPropertyName("author")] GitHubUser Author,
+                                         [property: JsonPropertyName("committer")] GitHubUser Committer,
                                          [property: JsonPropertyName("parents")] ImmutableArray<Tree> Parents,
                                          [property: JsonPropertyName("stats")] Stats Stats,
                                          [property: JsonPropertyName("files")] ImmutableArray<File> Files);
 
 public sealed record Commit([property: JsonPropertyName("url")] Uri Url,
-                            [property: JsonPropertyName("author")] CommitAuthor Author,
-                            [property: JsonPropertyName("committer")] CommitAuthor Committer,
+                            [property: JsonPropertyName("author")] CommitUser Author,
+                            [property: JsonPropertyName("committer")] CommitUser Committer,
                             [property: JsonPropertyName("message")] string Message,
                             [property: JsonPropertyName("tree")] Tree Tree,
                             [property: JsonPropertyName("comment_count")] int CommentCount,
                             [property: JsonPropertyName("verification")] Verification Verification);
-
-public sealed record CommitAuthor([property: JsonPropertyName("name")] string Name,
-                                  [property: JsonPropertyName("email")] string Email,
-                                  [property: JsonPropertyName("date")] DateTime Date);
+    
+public sealed record CommitUser([property: JsonPropertyName("name")] string Name,
+                                [property: JsonPropertyName("email")] string Email,
+                                [property: JsonPropertyName("date")] DateTime Date);
 
 public sealed record Tree([property: JsonPropertyName("url")] Uri Url,
                           [property: JsonPropertyName("sha")] string Sha);
@@ -265,27 +265,27 @@ public sealed record Verification([property: JsonPropertyName("verified")] bool 
                                   [property: JsonPropertyName("signature")] string? Signature,
                                   [property: JsonPropertyName("payload")] string? Payload);
 
-public sealed record Author([property: JsonPropertyName("login")] string Login,
-                            [property: JsonPropertyName("id")] int Id,
-                            [property: JsonPropertyName("node_id")] string NodeId,
-                            [property: JsonPropertyName("avatar_url")] Uri AvatarUrl,
-                            [property: JsonPropertyName("gravatar_id")] string GravatarId,
-                            [property: JsonPropertyName("url")] Uri Url,
-                            [property: JsonPropertyName("html_url")] Uri HtmlUrl,
-                            [property: JsonPropertyName("followers_url")] Uri FollowersUrl,
-                            [property: JsonPropertyName("following_url")] Uri FollowingUrl,
-                            [property: JsonPropertyName("gists_url")] Uri GistsUrl,
-                            [property: JsonPropertyName("starred_url")] Uri StarredUrl,
-                            [property: JsonPropertyName("subscriptions_url")] Uri SubscriptionsUrl,
-                            [property: JsonPropertyName("organizations_url")] Uri OrganizationsUrl,
-                            [property: JsonPropertyName("repos_url")] Uri ReposUrl,
-                            [property: JsonPropertyName("events_url")] Uri EventsUrl,
-                            [property: JsonPropertyName("received_events_url")] Uri ReceivedEventsUrl
-                            /*
-                             * Omitted because JsonReader.Object supports 16 properties.
-                             * [property: JsonPropertyName("type")] string Type,
-                             * [property: JsonPropertyName("site_admin")] bool SiteAdmin
-                             */);
+public sealed record GitHubUser([property: JsonPropertyName("login")] string Login,
+                                [property: JsonPropertyName("id")] int Id,
+                                [property: JsonPropertyName("node_id")] string NodeId,
+                                [property: JsonPropertyName("avatar_url")] Uri AvatarUrl,
+                                [property: JsonPropertyName("gravatar_id")] string GravatarId,
+                                [property: JsonPropertyName("url")] Uri Url,
+                                [property: JsonPropertyName("html_url")] Uri HtmlUrl,
+                                [property: JsonPropertyName("followers_url")] Uri FollowersUrl,
+                                [property: JsonPropertyName("following_url")] Uri FollowingUrl,
+                                [property: JsonPropertyName("gists_url")] Uri GistsUrl,
+                                [property: JsonPropertyName("starred_url")] Uri StarredUrl,
+                                [property: JsonPropertyName("subscriptions_url")] Uri SubscriptionsUrl,
+                                [property: JsonPropertyName("organizations_url")] Uri OrganizationsUrl,
+                                [property: JsonPropertyName("repos_url")] Uri ReposUrl,
+                                [property: JsonPropertyName("events_url")] Uri EventsUrl,
+                                [property: JsonPropertyName("received_events_url")] Uri ReceivedEventsUrl
+                                /*
+                                 * Omitted because JsonReader.Object supports 16 properties.
+                                 * [property: JsonPropertyName("type")] string Type,
+                                 * [property: JsonPropertyName("site_admin")] bool SiteAdmin
+                                 */);
 
 public sealed record Stats([property: JsonPropertyName("additions")] int Additions,
                            [property: JsonPropertyName("deletions")] int Deletions,

--- a/bench/GithubApiBenchmark.cs
+++ b/bench/GithubApiBenchmark.cs
@@ -115,6 +115,10 @@ public class GithubApiBenchmark
         }
         """;
 
+    private static readonly IJsonReader<Uri> UriReader =
+        from s in JsonReader.String()
+        select new Uri(s);
+
     private static readonly IJsonReader<Author> AuthorJsonReader =
         JsonReader.Object(JsonReader.Property("name", JsonReader.String()),
                           JsonReader.Property("email", JsonReader.String()),
@@ -122,7 +126,7 @@ public class GithubApiBenchmark
                           (name, email, date) => new Author(name, email, date));
 
     private static readonly IJsonReader<Commit> CommitJsonReader =
-        JsonReader.Object(JsonReader.Property("url", from s in JsonReader.String() select new Uri(s)),
+        JsonReader.Object(JsonReader.Property("url", UriReader),
                           JsonReader.Property("author", AuthorJsonReader),
                           JsonReader.Property("committer", AuthorJsonReader),
                           JsonReader.Property("message", JsonReader.String()),
@@ -131,7 +135,7 @@ public class GithubApiBenchmark
                               new Commit(url, author, committer, message, commentCount));
 
     static readonly IJsonReader<MergeBranchResponse> MergeBranchResponseJsonReader =
-        JsonReader.Object(JsonReader.Property("url", from s in JsonReader.String() select new Uri(s)),
+        JsonReader.Object(JsonReader.Property("url", UriReader),
                           JsonReader.Property("sha", JsonReader.String()),
                           JsonReader.Property("commit", CommitJsonReader),
                           (url, sha, commit) => new MergeBranchResponse(url, sha, commit));

--- a/bench/GithubApiBenchmark.cs
+++ b/bench/GithubApiBenchmark.cs
@@ -116,29 +116,29 @@ public class GithubApiBenchmark
         }
         """;
 
-    private static readonly IJsonReader<Uri> UriReader =
+    static readonly IJsonReader<Uri> UriReader =
         from s in JsonReader.String()
         select new Uri(s);
 
-    private static readonly IJsonReader<CommitAuthor> CommitAuthorJsonReader =
+    static readonly IJsonReader<CommitAuthor> CommitAuthorJsonReader =
         JsonReader.Object(JsonReader.Property("name", JsonReader.String()),
                           JsonReader.Property("email", JsonReader.String()),
                           JsonReader.Property("date", JsonReader.DateTime()),
                           (p1, p2, p3) => new CommitAuthor(p1, p2, p3));
 
-    private static readonly IJsonReader<Tree> TreeReader =
+    static readonly IJsonReader<Tree> TreeReader =
         JsonReader.Object(JsonReader.Property("url", UriReader),
                           JsonReader.Property("sha", JsonReader.String()),
                           (p1, p2) => new Tree(p1, p2));
 
-    private static readonly IJsonReader<Verification> VerificationReader =
+    static readonly IJsonReader<Verification> VerificationReader =
         JsonReader.Object(JsonReader.Property("verified", JsonReader.Boolean()),
                           JsonReader.Property("reason", JsonReader.String()),
                           JsonReader.Property("signature", JsonReader.String()),
                           JsonReader.Property("payload", JsonReader.String()),
                           (p1, p2, p3, p4) => new Verification(p1, p2, p3, p4));
 
-    private static readonly IJsonReader<Commit> CommitJsonReader =
+    static readonly IJsonReader<Commit> CommitJsonReader =
         JsonReader.Object(JsonReader.Property("url", UriReader),
                           JsonReader.Property("author", CommitAuthorJsonReader),
                           JsonReader.Property("committer", CommitAuthorJsonReader),
@@ -149,7 +149,7 @@ public class GithubApiBenchmark
                           (p1, p2, p3, p4, p5, p6, p7) =>
                               new Commit(p1, p2, p3, p4, p5, p6, p7));
 
-    private static readonly IJsonReader<Author> AuthorJsonReader =
+    static readonly IJsonReader<Author> AuthorJsonReader =
         JsonReader.Object(JsonReader.Property("login", JsonReader.String()),
                           JsonReader.Property("id", JsonReader.Int32()),
                           JsonReader.Property("node_id", JsonReader.String()),

--- a/bench/GithubApiBenchmark.cs
+++ b/bench/GithubApiBenchmark.cs
@@ -124,20 +124,19 @@ public class GithubApiBenchmark
         JsonReader.Object(JsonReader.Property("name", JsonReader.String()),
                           JsonReader.Property("email", JsonReader.String()),
                           JsonReader.Property("date", JsonReader.DateTime()),
-                          (name, email, date) => new CommitAuthor(name, email, date));
+                          (p1, p2, p3) => new CommitAuthor(p1, p2, p3));
 
     private static readonly IJsonReader<Tree> TreeReader =
         JsonReader.Object(JsonReader.Property("url", UriReader),
                           JsonReader.Property("sha", JsonReader.String()),
-                          (url, sha) => new Tree(url, sha));
+                          (p1, p2) => new Tree(p1, p2));
 
     private static readonly IJsonReader<Verification> VerificationReader =
         JsonReader.Object(JsonReader.Property("verified", JsonReader.Boolean()),
                           JsonReader.Property("reason", JsonReader.String()),
                           JsonReader.Property("signature", JsonReader.String()),
                           JsonReader.Property("payload", JsonReader.String()),
-                          (verified, reason, signature, payload) =>
-                              new Verification(verified, reason, signature, payload));
+                          (p1, p2, p3, p4) => new Verification(p1, p2, p3, p4));
 
     private static readonly IJsonReader<Commit> CommitJsonReader =
         JsonReader.Object(JsonReader.Property("url", UriReader),
@@ -147,8 +146,8 @@ public class GithubApiBenchmark
                           JsonReader.Property("tree", TreeReader),
                           JsonReader.Property("comment_count", JsonReader.Int32()),
                           JsonReader.Property("verification", VerificationReader),
-                          (url, author, committer, message, tree, commentCount, verification) =>
-                              new Commit(url, author, committer, message, tree, commentCount, verification));
+                          (p1, p2, p3, p4, p5, p6, p7) =>
+                              new Commit(p1, p2, p3, p4, p5, p6, p7));
 
     private static readonly IJsonReader<Author> AuthorJsonReader =
         JsonReader.Object(JsonReader.Property("login", JsonReader.String()),
@@ -179,7 +178,7 @@ public class GithubApiBenchmark
         JsonReader.Object(JsonReader.Property("additions", JsonReader.Int32()),
                           JsonReader.Property("deletions", JsonReader.Int32()),
                           JsonReader.Property("total", JsonReader.Int32()),
-                          (additions, deletions, total) => new Stats(additions, deletions, total));
+                          (p1, p2, p3) => new Stats(p1, p2, p3));
 
     static readonly IJsonReader<File> FileReader =
         JsonReader.Object(JsonReader.Property("filename", JsonReader.String()),
@@ -205,8 +204,8 @@ public class GithubApiBenchmark
                           JsonReader.Property("parents", TreeReader),
                           JsonReader.Property("stats", StatsReader),
                           JsonReader.Property("files", JsonReader.Array(FileReader)),
-                          (url, sha, nodeId, htmlUrl, commentsUrl, commit, author, committer, parents, stats, files) =>
-                              new MergeBranchResponse(url, sha, nodeId, htmlUrl, commentsUrl, commit, author, committer, parents, stats, files.ToImmutableArray()));
+                          (p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11) =>
+                              new MergeBranchResponse(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11.ToImmutableArray()));
 
     [Params(10, 100, 1000, 10000)] public int ObjectCount { get; set; }
 

--- a/bench/GithubApiBenchmark.cs
+++ b/bench/GithubApiBenchmark.cs
@@ -208,10 +208,10 @@ public class GithubApiBenchmark
                               new MergeBranchResponse(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11));
 
     static IJsonReader<T?> Nullable<T>(IJsonReader<T> reader, T? @null) =>
-        JsonReader.Either(JsonReader.Null(@null), from v in reader select v);
+        JsonReader.Either(JsonReader.Null(@null), from v in reader select (T?)v);
 
     static IJsonReader<ImmutableArray<T>> ImmutableArrayReader<T>(IJsonReader<T> reader) =>
-        from v in JsonReader.Array(reader) select v.ToImmutableArray();
+        JsonReader.Array(reader, list => list.ToImmutableArray());
 
     [Params(10, 100, 1000, 10000)] public int ObjectCount { get; set; }
 

--- a/bench/GithubApiBenchmark.cs
+++ b/bench/GithubApiBenchmark.cs
@@ -120,7 +120,7 @@ public class GithubApiBenchmark
         from s in JsonReader.String()
         select new Uri(s);
 
-    static readonly IJsonReader<CommitAuthor> CommitAuthorJsonReader =
+    static readonly IJsonReader<CommitAuthor> CommitAuthorReader =
         JsonReader.Object(JsonReader.Property("name", JsonReader.String()),
                           JsonReader.Property("email", JsonReader.String()),
                           JsonReader.Property("date", JsonReader.DateTime()),
@@ -138,10 +138,10 @@ public class GithubApiBenchmark
                           JsonReader.Property("payload", JsonReader.String()),
                           (p1, p2, p3, p4) => new Verification(p1, p2, p3, p4));
 
-    static readonly IJsonReader<Commit> CommitJsonReader =
+    static readonly IJsonReader<Commit> CommitReader =
         JsonReader.Object(JsonReader.Property("url", UriReader),
-                          JsonReader.Property("author", CommitAuthorJsonReader),
-                          JsonReader.Property("committer", CommitAuthorJsonReader),
+                          JsonReader.Property("author", CommitAuthorReader),
+                          JsonReader.Property("committer", CommitAuthorReader),
                           JsonReader.Property("message", JsonReader.String()),
                           JsonReader.Property("tree", TreeReader),
                           JsonReader.Property("comment_count", JsonReader.Int32()),
@@ -149,7 +149,7 @@ public class GithubApiBenchmark
                           (p1, p2, p3, p4, p5, p6, p7) =>
                               new Commit(p1, p2, p3, p4, p5, p6, p7));
 
-    static readonly IJsonReader<Author> AuthorJsonReader =
+    static readonly IJsonReader<Author> AuthorReader =
         JsonReader.Object(JsonReader.Property("login", JsonReader.String()),
                           JsonReader.Property("id", JsonReader.Int32()),
                           JsonReader.Property("node_id", JsonReader.String()),
@@ -192,15 +192,15 @@ public class GithubApiBenchmark
                           (p1, p2, p3, p4, p5, p6, p7, p8) =>
                               new File(p1, p2, p3, p4, p5, p6, p7, p8));
 
-    static readonly IJsonReader<MergeBranchResponse> MergeBranchResponseJsonReader =
+    static readonly IJsonReader<MergeBranchResponse> MergeBranchResponseReader =
         JsonReader.Object(JsonReader.Property("url", UriReader),
                           JsonReader.Property("sha", JsonReader.String()),
                           JsonReader.Property("node_id", JsonReader.String()),
                           JsonReader.Property("html_url", UriReader),
                           JsonReader.Property("comments_url", UriReader),
-                          JsonReader.Property("commit", CommitJsonReader),
-                          JsonReader.Property("author", AuthorJsonReader),
-                          JsonReader.Property("committer", AuthorJsonReader),
+                          JsonReader.Property("commit", CommitReader),
+                          JsonReader.Property("author", AuthorReader),
+                          JsonReader.Property("committer", AuthorReader),
                           JsonReader.Property("parents", TreeReader),
                           JsonReader.Property("stats", StatsReader),
                           JsonReader.Property("files", JsonReader.Array(FileReader)),
@@ -220,7 +220,7 @@ public class GithubApiBenchmark
 
     [Benchmark]
     public MergeBranchResponse[] JsonReaderBenchmark() =>
-        JsonReader.Array(MergeBranchResponseJsonReader).Read(this.jsonDataBytes);
+        JsonReader.Array(MergeBranchResponseReader).Read(this.jsonDataBytes);
 
     [Benchmark(Baseline = true)]
     public MergeBranchResponse[] SystemTextJsonBenchmark() =>

--- a/bench/GithubApiBenchmark.cs
+++ b/bench/GithubApiBenchmark.cs
@@ -120,36 +120,36 @@ public class GithubApiBenchmark
         from s in JsonReader.String()
         select new Uri(s);
 
-    static readonly IJsonReader<CommitAuthor> CommitAuthorReader =
+    static readonly IJsonReader<CommitAuthor> CommitAuthorJsonReader =
         JsonReader.Object(JsonReader.Property("name", JsonReader.String()),
                           JsonReader.Property("email", JsonReader.String()),
                           JsonReader.Property("date", JsonReader.DateTime()),
                           (p1, p2, p3) => new CommitAuthor(p1, p2, p3));
 
-    static readonly IJsonReader<Tree> TreeReader =
+    static readonly IJsonReader<Tree> TreeJsonReader =
         JsonReader.Object(JsonReader.Property("url", UriReader),
                           JsonReader.Property("sha", JsonReader.String()),
                           (p1, p2) => new Tree(p1, p2));
 
-    static readonly IJsonReader<Verification> VerificationReader =
+    static readonly IJsonReader<Verification> VerificationJsonReader =
         JsonReader.Object(JsonReader.Property("verified", JsonReader.Boolean()),
                           JsonReader.Property("reason", JsonReader.String()),
                           JsonReader.Property("signature", Nullable(JsonReader.String(), null)),
                           JsonReader.Property("payload", Nullable(JsonReader.String(), null)),
                           (p1, p2, p3, p4) => new Verification(p1, p2, p3, p4));
 
-    static readonly IJsonReader<Commit> CommitReader =
+    static readonly IJsonReader<Commit> CommitJsonReader =
         JsonReader.Object(JsonReader.Property("url", UriReader),
-                          JsonReader.Property("author", CommitAuthorReader),
-                          JsonReader.Property("committer", CommitAuthorReader),
+                          JsonReader.Property("author", CommitAuthorJsonReader),
+                          JsonReader.Property("committer", CommitAuthorJsonReader),
                           JsonReader.Property("message", JsonReader.String()),
-                          JsonReader.Property("tree", TreeReader),
+                          JsonReader.Property("tree", TreeJsonReader),
                           JsonReader.Property("comment_count", JsonReader.Int32()),
-                          JsonReader.Property("verification", VerificationReader),
+                          JsonReader.Property("verification", VerificationJsonReader),
                           (p1, p2, p3, p4, p5, p6, p7) =>
                               new Commit(p1, p2, p3, p4, p5, p6, p7));
 
-    static readonly IJsonReader<Author> AuthorReader =
+    static readonly IJsonReader<Author> AuthorJsonReader =
         JsonReader.Object(JsonReader.Property("login", JsonReader.String()),
                           JsonReader.Property("id", JsonReader.Int32()),
                           JsonReader.Property("node_id", JsonReader.String()),
@@ -174,13 +174,13 @@ public class GithubApiBenchmark
                           (p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16) =>
                               new Author(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16));
 
-    static readonly IJsonReader<Stats> StatsReader =
+    static readonly IJsonReader<Stats> StatsJsonReader =
         JsonReader.Object(JsonReader.Property("additions", JsonReader.Int32()),
                           JsonReader.Property("deletions", JsonReader.Int32()),
                           JsonReader.Property("total", JsonReader.Int32()),
                           (p1, p2, p3) => new Stats(p1, p2, p3));
 
-    static readonly IJsonReader<File> FileReader =
+    static readonly IJsonReader<File> FileJsonReader =
         JsonReader.Object(JsonReader.Property("filename", JsonReader.String()),
                           JsonReader.Property("additions", JsonReader.Int32()),
                           JsonReader.Property("deletions", JsonReader.Int32()),
@@ -192,18 +192,18 @@ public class GithubApiBenchmark
                           (p1, p2, p3, p4, p5, p6, p7, p8) =>
                               new File(p1, p2, p3, p4, p5, p6, p7, p8));
 
-    static readonly IJsonReader<MergeBranchResponse> MergeBranchResponseReader =
+    static readonly IJsonReader<MergeBranchResponse> MergeBranchResponseJsonReader =
         JsonReader.Object(JsonReader.Property("url", UriReader),
                           JsonReader.Property("sha", JsonReader.String()),
                           JsonReader.Property("node_id", JsonReader.String()),
                           JsonReader.Property("html_url", UriReader),
                           JsonReader.Property("comments_url", UriReader),
-                          JsonReader.Property("commit", CommitReader),
-                          JsonReader.Property("author", AuthorReader),
-                          JsonReader.Property("committer", AuthorReader),
-                          JsonReader.Property("parents", ImmutableArrayReader(TreeReader)),
-                          JsonReader.Property("stats", StatsReader),
-                          JsonReader.Property("files", ImmutableArrayReader(FileReader)),
+                          JsonReader.Property("commit", CommitJsonReader),
+                          JsonReader.Property("author", AuthorJsonReader),
+                          JsonReader.Property("committer", AuthorJsonReader),
+                          JsonReader.Property("parents", ImmutableArrayReader(TreeJsonReader)),
+                          JsonReader.Property("stats", StatsJsonReader),
+                          JsonReader.Property("files", ImmutableArrayReader(FileJsonReader)),
                           (p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11) =>
                               new MergeBranchResponse(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11));
 
@@ -226,7 +226,7 @@ public class GithubApiBenchmark
 
     [Benchmark]
     public MergeBranchResponse[] JsonReaderBenchmark() =>
-        JsonReader.Array(MergeBranchResponseReader).Read(this.jsonDataBytes);
+        JsonReader.Array(MergeBranchResponseJsonReader).Read(this.jsonDataBytes);
 
     [Benchmark(Baseline = true)]
     public MergeBranchResponse[] SystemTextJsonBenchmark() =>

--- a/bench/GithubApiBenchmark.cs
+++ b/bench/GithubApiBenchmark.cs
@@ -130,6 +130,14 @@ public class GithubApiBenchmark
                           JsonReader.Property("sha", JsonReader.String()),
                           (url, sha) => new Tree(url, sha));
 
+    private static readonly IJsonReader<Verification> VerificationReader =
+        JsonReader.Object(JsonReader.Property("verified", JsonReader.Boolean()),
+                          JsonReader.Property("reason", JsonReader.String()),
+                          JsonReader.Property("signature", JsonReader.String()),
+                          JsonReader.Property("payload", JsonReader.String()),
+                          (verified, reason, signature, payload) =>
+                              new Verification(verified, reason, signature, payload));
+
     private static readonly IJsonReader<Commit> CommitJsonReader =
         JsonReader.Object(JsonReader.Property("url", UriReader),
                           JsonReader.Property("author", AuthorJsonReader),
@@ -137,14 +145,18 @@ public class GithubApiBenchmark
                           JsonReader.Property("message", JsonReader.String()),
                           JsonReader.Property("tree", TreeReader),
                           JsonReader.Property("comment_count", JsonReader.Int32()),
-                          (url, author, committer, message, tree, commentCount) =>
-                              new Commit(url, author, committer, message, tree, commentCount));
+                          JsonReader.Property("verification", VerificationReader),
+                          (url, author, committer, message, tree, commentCount, verification) =>
+                              new Commit(url, author, committer, message, tree, commentCount, verification));
 
     static readonly IJsonReader<MergeBranchResponse> MergeBranchResponseJsonReader =
         JsonReader.Object(JsonReader.Property("url", UriReader),
                           JsonReader.Property("sha", JsonReader.String()),
+                          JsonReader.Property("node_id", JsonReader.String()),
+                          JsonReader.Property("html_url", UriReader),
+                          JsonReader.Property("comments_url", UriReader),
                           JsonReader.Property("commit", CommitJsonReader),
-                          (url, sha, commit) => new MergeBranchResponse(url, sha, commit));
+                          (url, sha, node_id, htmlUrl, commentsUrl, commit) => new MergeBranchResponse(url, sha, node_id, htmlUrl, commentsUrl, commit));
 
     [Params(10, 100, 1000, 10000)] public int ObjectCount { get; set; }
 
@@ -168,6 +180,9 @@ public class GithubApiBenchmark
 
 public sealed record MergeBranchResponse([property: JsonPropertyName("url")] Uri Url,
                                          [property: JsonPropertyName("sha")] string Sha,
+                                         [property: JsonPropertyName("node_id")] string NodeId,
+                                         [property: JsonPropertyName("html_url")] Uri HtmlUrl,
+                                         [property: JsonPropertyName("comments_url")] Uri CommentsUrl,
                                          [property: JsonPropertyName("commit")] Commit Commit);
 
 public sealed record Commit([property: JsonPropertyName("url")] Uri Url,
@@ -175,7 +190,8 @@ public sealed record Commit([property: JsonPropertyName("url")] Uri Url,
                             [property: JsonPropertyName("committer")] Author Committer,
                             [property: JsonPropertyName("message")] string Message,
                             [property: JsonPropertyName("tree")] Tree Tree,
-                            [property: JsonPropertyName("comment_count")] int CommentCount);
+                            [property: JsonPropertyName("comment_count")] int CommentCount,
+                            [property: JsonPropertyName("verification")] Verification Verification);
 
 public sealed record Author([property: JsonPropertyName("name")] string Name,
                             [property: JsonPropertyName("email")] string Email,
@@ -183,3 +199,8 @@ public sealed record Author([property: JsonPropertyName("name")] string Name,
 
 public sealed record Tree([property: JsonPropertyName("url")] Uri Url,
                           [property: JsonPropertyName("sha")] string Sha);
+
+public sealed record Verification([property: JsonPropertyName("verified")] bool Verified,
+                                  [property: JsonPropertyName("reason")] string Reason,
+                                  [property: JsonPropertyName("signature")] string Signature,
+                                  [property: JsonPropertyName("payload")] string Payload);

--- a/bench/GithubApiBenchmark.cs
+++ b/bench/GithubApiBenchmark.cs
@@ -182,8 +182,9 @@ public class GithubApiBenchmark
                           JsonReader.Property("comments_url", UriReader),
                           JsonReader.Property("commit", CommitJsonReader),
                           JsonReader.Property("author", AuthorJsonReader),
-                          (url, sha, node_id, htmlUrl, commentsUrl, commit, author) =>
-                              new MergeBranchResponse(url, sha, node_id, htmlUrl, commentsUrl, commit, author));
+                          JsonReader.Property("committer", AuthorJsonReader),
+                          (url, sha, node_id, htmlUrl, commentsUrl, commit, author, committer) =>
+                              new MergeBranchResponse(url, sha, node_id, htmlUrl, commentsUrl, commit, author, committer));
 
     [Params(10, 100, 1000, 10000)] public int ObjectCount { get; set; }
 
@@ -211,7 +212,8 @@ public sealed record MergeBranchResponse([property: JsonPropertyName("url")] Uri
                                          [property: JsonPropertyName("html_url")] Uri HtmlUrl,
                                          [property: JsonPropertyName("comments_url")] Uri CommentsUrl,
                                          [property: JsonPropertyName("commit")] Commit Commit,
-                                         [property: JsonPropertyName("author")] Author Author);
+                                         [property: JsonPropertyName("author")] Author Author,
+                                         [property: JsonPropertyName("committer")] Author Committer);
 
 public sealed record Commit([property: JsonPropertyName("url")] Uri Url,
                             [property: JsonPropertyName("author")] CommitAuthor Author,

--- a/bench/GithubApiBenchmark.cs
+++ b/bench/GithubApiBenchmark.cs
@@ -119,11 +119,11 @@ public class GithubApiBenchmark
         from s in JsonReader.String()
         select new Uri(s);
 
-    private static readonly IJsonReader<Author> AuthorJsonReader =
+    private static readonly IJsonReader<CommitAuthor> CommitAuthorJsonReader =
         JsonReader.Object(JsonReader.Property("name", JsonReader.String()),
                           JsonReader.Property("email", JsonReader.String()),
                           JsonReader.Property("date", JsonReader.DateTime()),
-                          (name, email, date) => new Author(name, email, date));
+                          (name, email, date) => new CommitAuthor(name, email, date));
 
     private static readonly IJsonReader<Tree> TreeReader =
         JsonReader.Object(JsonReader.Property("url", UriReader),
@@ -140,14 +140,39 @@ public class GithubApiBenchmark
 
     private static readonly IJsonReader<Commit> CommitJsonReader =
         JsonReader.Object(JsonReader.Property("url", UriReader),
-                          JsonReader.Property("author", AuthorJsonReader),
-                          JsonReader.Property("committer", AuthorJsonReader),
+                          JsonReader.Property("author", CommitAuthorJsonReader),
+                          JsonReader.Property("committer", CommitAuthorJsonReader),
                           JsonReader.Property("message", JsonReader.String()),
                           JsonReader.Property("tree", TreeReader),
                           JsonReader.Property("comment_count", JsonReader.Int32()),
                           JsonReader.Property("verification", VerificationReader),
                           (url, author, committer, message, tree, commentCount, verification) =>
                               new Commit(url, author, committer, message, tree, commentCount, verification));
+
+    private static readonly IJsonReader<Author> AuthorJsonReader =
+        JsonReader.Object(JsonReader.Property("login", JsonReader.String()),
+                          JsonReader.Property("id", JsonReader.Int32()),
+                          JsonReader.Property("node_id", JsonReader.String()),
+                          JsonReader.Property("avatar_url", UriReader),
+                          JsonReader.Property("gravatar_id", JsonReader.String()),
+                          JsonReader.Property("url", UriReader),
+                          JsonReader.Property("html_url", UriReader),
+                          JsonReader.Property("followers_url", UriReader),
+                          JsonReader.Property("following_url", UriReader),
+                          JsonReader.Property("gists_url", UriReader),
+                          JsonReader.Property("starred_url", UriReader),
+                          JsonReader.Property("subscriptions_url", UriReader),
+                          JsonReader.Property("organizations_url", UriReader),
+                          JsonReader.Property("repos_url", UriReader),
+                          JsonReader.Property("events_url", UriReader),
+                          JsonReader.Property("received_events_url", UriReader),
+                          /*
+                           * Omitted because JsonReader.Object supports 16 properties.
+                           * JsonReader.Property("type", JsonReader.String()),
+                           * JsonReader.Property("site_admin", JsonReader.Boolean()
+                           */
+                          (p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16) =>
+                              new Author(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16));
 
     static readonly IJsonReader<MergeBranchResponse> MergeBranchResponseJsonReader =
         JsonReader.Object(JsonReader.Property("url", UriReader),
@@ -156,7 +181,9 @@ public class GithubApiBenchmark
                           JsonReader.Property("html_url", UriReader),
                           JsonReader.Property("comments_url", UriReader),
                           JsonReader.Property("commit", CommitJsonReader),
-                          (url, sha, node_id, htmlUrl, commentsUrl, commit) => new MergeBranchResponse(url, sha, node_id, htmlUrl, commentsUrl, commit));
+                          JsonReader.Property("author", AuthorJsonReader),
+                          (url, sha, node_id, htmlUrl, commentsUrl, commit, author) =>
+                              new MergeBranchResponse(url, sha, node_id, htmlUrl, commentsUrl, commit, author));
 
     [Params(10, 100, 1000, 10000)] public int ObjectCount { get; set; }
 
@@ -183,19 +210,20 @@ public sealed record MergeBranchResponse([property: JsonPropertyName("url")] Uri
                                          [property: JsonPropertyName("node_id")] string NodeId,
                                          [property: JsonPropertyName("html_url")] Uri HtmlUrl,
                                          [property: JsonPropertyName("comments_url")] Uri CommentsUrl,
-                                         [property: JsonPropertyName("commit")] Commit Commit);
+                                         [property: JsonPropertyName("commit")] Commit Commit,
+                                         [property: JsonPropertyName("author")] Author Author);
 
 public sealed record Commit([property: JsonPropertyName("url")] Uri Url,
-                            [property: JsonPropertyName("author")] Author Author,
-                            [property: JsonPropertyName("committer")] Author Committer,
+                            [property: JsonPropertyName("author")] CommitAuthor Author,
+                            [property: JsonPropertyName("committer")] CommitAuthor Committer,
                             [property: JsonPropertyName("message")] string Message,
                             [property: JsonPropertyName("tree")] Tree Tree,
                             [property: JsonPropertyName("comment_count")] int CommentCount,
                             [property: JsonPropertyName("verification")] Verification Verification);
 
-public sealed record Author([property: JsonPropertyName("name")] string Name,
-                            [property: JsonPropertyName("email")] string Email,
-                            [property: JsonPropertyName("date")] DateTime Date);
+public sealed record CommitAuthor([property: JsonPropertyName("name")] string Name,
+                                  [property: JsonPropertyName("email")] string Email,
+                                  [property: JsonPropertyName("date")] DateTime Date);
 
 public sealed record Tree([property: JsonPropertyName("url")] Uri Url,
                           [property: JsonPropertyName("sha")] string Sha);
@@ -204,3 +232,25 @@ public sealed record Verification([property: JsonPropertyName("verified")] bool 
                                   [property: JsonPropertyName("reason")] string Reason,
                                   [property: JsonPropertyName("signature")] string Signature,
                                   [property: JsonPropertyName("payload")] string Payload);
+
+public sealed record Author([property: JsonPropertyName("login")] string Login,
+                            [property: JsonPropertyName("id")] int Id,
+                            [property: JsonPropertyName("node_id")] string NodeId,
+                            [property: JsonPropertyName("avatar_url")] Uri AvatarUrl,
+                            [property: JsonPropertyName("gravatar_id")] string GravatarId,
+                            [property: JsonPropertyName("url")] Uri Url,
+                            [property: JsonPropertyName("html_url")] Uri HtmlUrl,
+                            [property: JsonPropertyName("followers_url")] Uri FollowersUrl,
+                            [property: JsonPropertyName("following_url")] Uri FollowingUrl,
+                            [property: JsonPropertyName("gists_url")] Uri GistsUrl,
+                            [property: JsonPropertyName("starred_url")] Uri StarredUrl,
+                            [property: JsonPropertyName("subscriptions_url")] Uri SubscriptionsUrl,
+                            [property: JsonPropertyName("organizations_url")] Uri OrganizationsUrl,
+                            [property: JsonPropertyName("repos_url")] Uri ReposUrl,
+                            [property: JsonPropertyName("events_url")] Uri EventsUrl,
+                            [property: JsonPropertyName("received_events_url")] Uri ReceivedEventsUrl
+                            /*
+                             * Omitted because JsonReader.Object supports 16 properties.
+                             * [property: JsonPropertyName("type")] string Type,
+                             * [property: JsonPropertyName("site_admin")] bool SiteAdmin
+                             */);

--- a/bench/README.md
+++ b/bench/README.md
@@ -89,38 +89,39 @@ When benchmarking deserialization a subset of an example payload from the
     Intel Core i7-1065G7 CPU 1.30GHz, 1 CPU, 8 logical and 4 physical cores
     .NET SDK=7.0.100
       [Host]     : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
-      Job-FRBYQO : .NET 6.0.11 (6.0.1122.52304), X64 RyuJIT AVX2
-      Job-FPUDIR : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
-      Job-MSXFTZ : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
+      Job-OVWNPR : .NET 6.0.11 (6.0.1122.52304), X64 RyuJIT AVX2
+      Job-KJBBGH : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
+      Job-CKYCTW : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
 
-|                  Method |       Runtime | ObjectCount |         Mean |        Error |        StdDev |       Median | Ratio | RatioSD |       Gen0 |      Gen1 |      Gen2 |   Allocated | Alloc Ratio |
-|------------------------ |-------------- |------------ |-------------:|-------------:|--------------:|-------------:|------:|--------:|-----------:|----------:|----------:|------------:|------------:|
-|     JsonReaderBenchmark |      .NET 6.0 |          10 |     430.4 us |     28.69 us |      83.68 us |     399.1 us |  1.47 |    0.35 |    20.5078 |    6.8359 |         - |     84.3 KB |        0.86 |
-| SystemTextJsonBenchmark |      .NET 6.0 |          10 |     342.9 us |     21.17 us |      60.41 us |     324.5 us |  1.16 |    0.23 |    23.9258 |    7.8125 |         - |     98.9 KB |        1.01 |
-|     JsonReaderBenchmark |      .NET 7.0 |          10 |     408.1 us |     18.34 us |      52.33 us |     394.3 us |  1.39 |    0.24 |    20.5078 |    6.8359 |         - |     84.3 KB |        0.86 |
-| SystemTextJsonBenchmark |      .NET 7.0 |          10 |     314.7 us |     14.64 us |      43.18 us |     306.6 us |  1.08 |    0.21 |    23.9258 |    7.8125 |         - |    98.07 KB |        1.00 |
-|     JsonReaderBenchmark | NativeAOT 7.0 |          10 |     398.1 us |     17.66 us |      49.82 us |     387.5 us |  1.35 |    0.24 |    20.5078 |    6.8359 |         - |     84.3 KB |        0.86 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 |          10 |     296.6 us |     12.51 us |      36.50 us |     286.7 us |  1.00 |    0.00 |    23.9258 |    7.8125 |         - |    98.07 KB |        1.00 |
-|                         |               |             |              |              |               |              |       |         |            |           |           |             |             |
-|     JsonReaderBenchmark |      .NET 6.0 |         100 |   6,259.1 us |    533.00 us |   1,546.33 us |   5,817.0 us |  1.48 |    0.51 |   125.0000 |   62.5000 |         - |   840.58 KB |        0.85 |
-| SystemTextJsonBenchmark |      .NET 6.0 |         100 |   3,492.2 us |    136.55 us |     400.47 us |   3,368.7 us |  0.83 |    0.25 |   156.2500 |   78.1250 |         - |   994.96 KB |        1.01 |
-|     JsonReaderBenchmark |      .NET 7.0 |         100 |   4,276.0 us |    154.20 us |     442.41 us |   4,196.1 us |  1.02 |    0.30 |   136.7188 |  132.8125 |         - |   840.57 KB |        0.85 |
-| SystemTextJsonBenchmark |      .NET 7.0 |         100 |   3,223.2 us |    122.33 us |     352.94 us |   3,149.5 us |  0.78 |    0.26 |   160.1563 |  156.2500 |         - |   986.39 KB |        1.00 |
-|     JsonReaderBenchmark | NativeAOT 7.0 |         100 |   4,150.3 us |    174.82 us |     509.97 us |   4,048.6 us |  0.98 |    0.29 |   132.8125 |  125.0000 |         - |   840.57 KB |        0.85 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 |         100 |   4,558.2 us |    472.24 us |   1,362.52 us |   4,660.4 us |  1.00 |    0.00 |   160.1563 |  156.2500 |         - |   986.39 KB |        1.00 |
-|                         |               |             |              |              |               |              |       |         |            |           |           |             |             |
-|     JsonReaderBenchmark |      .NET 6.0 |        1000 |  78,578.1 us |  2,843.35 us |   8,066.12 us |  77,615.7 us |  1.01 |    0.15 |  1428.5714 |  571.4286 |  142.8571 |  8400.03 KB |        0.86 |
-| SystemTextJsonBenchmark |      .NET 6.0 |        1000 |  69,825.7 us |  2,688.92 us |   7,801.03 us |  68,575.6 us |  0.89 |    0.13 |  1625.0000 |  625.0000 |  125.0000 |  9875.27 KB |        1.01 |
-|     JsonReaderBenchmark |      .NET 7.0 |        1000 |  82,837.1 us |  3,608.50 us |  10,236.71 us |  79,817.6 us |  1.06 |    0.18 |  1428.5714 |  714.2857 |  142.8571 |  8399.49 KB |        0.86 |
-| SystemTextJsonBenchmark |      .NET 7.0 |        1000 |  75,251.8 us |  2,680.40 us |   7,733.57 us |  73,726.0 us |  0.96 |    0.13 |  1750.0000 | 1000.0000 |  250.0000 |   9789.3 KB |        1.00 |
-|     JsonReaderBenchmark | NativeAOT 7.0 |        1000 |  86,595.5 us |  3,068.95 us |   8,755.89 us |  85,300.8 us |  1.11 |    0.16 |  1428.5714 |  714.2857 |  142.8571 |  8399.27 KB |        0.86 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 |        1000 |  79,225.8 us |  3,401.67 us |   9,538.64 us |  79,016.5 us |  1.00 |    0.00 |  1750.0000 | 1000.0000 |  250.0000 |  9789.97 KB |        1.00 |
-|                         |               |             |              |              |               |              |       |         |            |           |           |             |             |
-|     JsonReaderBenchmark |      .NET 6.0 |       10000 | 884,528.8 us | 35,333.94 us | 103,628.32 us | 869,597.0 us |  1.29 |    0.22 | 13000.0000 | 5000.0000 |         - | 84084.95 KB |        0.86 |
-| SystemTextJsonBenchmark |      .NET 6.0 |       10000 | 768,371.6 us | 38,170.42 us | 110,130.39 us | 753,314.5 us |  1.13 |    0.23 | 15000.0000 | 5000.0000 |         - | 98321.43 KB |        1.01 |
-|     JsonReaderBenchmark |      .NET 7.0 |       10000 | 818,645.8 us | 28,842.23 us |  82,753.76 us | 811,705.2 us |  1.19 |    0.16 | 14000.0000 | 7000.0000 | 1000.0000 |  84089.4 KB |        0.86 |
-| SystemTextJsonBenchmark |      .NET 7.0 |       10000 | 704,268.1 us | 23,270.90 us |  68,614.77 us | 700,178.7 us |  1.03 |    0.16 | 16000.0000 | 8000.0000 | 1000.0000 |  97463.8 KB |        1.00 |
-|     JsonReaderBenchmark | NativeAOT 7.0 |       10000 | 822,064.3 us | 31,849.32 us |  92,400.64 us | 821,875.3 us |  1.20 |    0.18 | 14000.0000 | 7000.0000 | 1000.0000 | 84088.01 KB |        0.86 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 |       10000 | 693,208.3 us | 26,231.06 us |  74,838.70 us | 692,791.7 us |  1.00 |    0.00 | 16000.0000 | 8000.0000 | 1000.0000 | 97469.13 KB |        1.00 |
+
+|                  Method |       Runtime | ObjectCount |         Mean |        Error |       StdDev |       Median | Ratio | RatioSD |       Gen0 |      Gen1 |      Gen2 |   Allocated | Alloc Ratio |
+|------------------------ |-------------- |------------ |-------------:|-------------:|-------------:|-------------:|------:|--------:|-----------:|----------:|----------:|------------:|------------:|
+|     JsonReaderBenchmark |      .NET 6.0 |          10 |     361.1 us |     11.90 us |     33.17 us |     353.0 us |  1.23 |    0.21 |    19.5313 |    5.8594 |         - |    83.67 KB |        0.85 |
+| SystemTextJsonBenchmark |      .NET 6.0 |          10 |     249.3 us |      4.98 us |     13.64 us |     248.7 us |  0.84 |    0.12 |    23.9258 |    7.8125 |         - |     98.9 KB |        1.01 |
+|     JsonReaderBenchmark |      .NET 7.0 |          10 |     327.6 us |     10.28 us |     29.32 us |     318.4 us |  1.12 |    0.19 |    20.0195 |    1.9531 |         - |    83.67 KB |        0.85 |
+| SystemTextJsonBenchmark |      .NET 7.0 |          10 |     285.3 us |     13.16 us |     35.79 us |     273.4 us |  0.96 |    0.18 |    23.9258 |    7.8125 |         - |    98.07 KB |        1.00 |
+|     JsonReaderBenchmark | NativeAOT 7.0 |          10 |     406.9 us |     34.08 us |     94.44 us |     371.2 us |  1.37 |    0.30 |    20.0195 |    1.9531 |         - |    83.67 KB |        0.85 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 |          10 |     298.6 us |     16.48 us |     46.50 us |     285.7 us |  1.00 |    0.00 |    23.9258 |    7.8125 |         - |    98.07 KB |        1.00 |
+|                         |               |             |              |              |              |              |       |         |            |           |           |             |             |
+|     JsonReaderBenchmark |      .NET 6.0 |         100 |   3,867.9 us |    164.67 us |    456.31 us |   3,714.0 us |  1.28 |    0.23 |   132.8125 |   66.4063 |         - |   834.32 KB |        0.85 |
+| SystemTextJsonBenchmark |      .NET 6.0 |         100 |   3,363.0 us |    219.58 us |    615.72 us |   3,143.9 us |  1.12 |    0.27 |   160.1563 |   78.1250 |         - |   994.96 KB |        1.01 |
+|     JsonReaderBenchmark |      .NET 7.0 |         100 |   3,781.9 us |    131.40 us |    374.89 us |   3,689.5 us |  1.25 |    0.22 |   132.8125 |  128.9063 |         - |   834.32 KB |        0.85 |
+| SystemTextJsonBenchmark |      .NET 7.0 |         100 |   3,047.9 us |    154.99 us |    439.68 us |   2,928.2 us |  0.99 |    0.19 |   160.1563 |  156.2500 |         - |   986.39 KB |        1.00 |
+|     JsonReaderBenchmark | NativeAOT 7.0 |         100 |   3,733.0 us |    165.12 us |    465.73 us |   3,628.0 us |  1.25 |    0.24 |   132.8125 |  125.0000 |         - |   834.32 KB |        0.85 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 |         100 |   3,085.3 us |    185.14 us |    503.69 us |   2,935.6 us |  1.00 |    0.00 |   160.1563 |  156.2500 |         - |   986.39 KB |        1.00 |
+|                         |               |             |              |              |              |              |       |         |            |           |           |             |             |
+|     JsonReaderBenchmark |      .NET 6.0 |        1000 |  48,127.1 us |  2,503.79 us |  7,102.84 us |  45,877.2 us |  0.98 |    0.21 |  1400.0000 |  500.0000 |  100.0000 |  8336.78 KB |        0.85 |
+| SystemTextJsonBenchmark |      .NET 6.0 |        1000 |  44,739.9 us |  1,663.72 us |  4,800.22 us |  43,065.2 us |  0.91 |    0.18 |  1727.2727 |  727.2727 |  272.7273 |  9875.11 KB |        1.01 |
+|     JsonReaderBenchmark |      .NET 7.0 |        1000 |  53,535.8 us |  3,335.49 us |  9,676.85 us |  49,938.4 us |  1.09 |    0.25 |  1555.5556 |  888.8889 |  222.2222 |  8336.96 KB |        0.85 |
+| SystemTextJsonBenchmark |      .NET 7.0 |        1000 |  45,374.4 us |  1,225.50 us |  3,516.18 us |  44,875.0 us |  0.92 |    0.16 |  1833.3333 | 1083.3333 |  333.3333 |  9789.81 KB |        1.00 |
+|     JsonReaderBenchmark | NativeAOT 7.0 |        1000 |  53,250.5 us |  2,668.28 us |  7,569.46 us |  50,447.6 us |  1.09 |    0.26 |  1500.0000 |  875.0000 |  250.0000 |  8337.59 KB |        0.85 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 |        1000 |  50,615.8 us |  3,317.44 us |  9,356.91 us |  48,137.7 us |  1.00 |    0.00 |  1818.1818 | 1000.0000 |  272.7273 |  9789.16 KB |        1.00 |
+|                         |               |             |              |              |              |              |       |         |            |           |           |             |             |
+|     JsonReaderBenchmark |      .NET 6.0 |       10000 | 473,801.2 us | 18,509.33 us | 51,902.14 us | 455,522.1 us |  1.24 |    0.19 | 13000.0000 | 5000.0000 |         - | 83459.95 KB |        0.86 |
+| SystemTextJsonBenchmark |      .NET 6.0 |       10000 | 402,131.6 us | 12,635.45 us | 36,049.65 us | 391,502.2 us |  1.05 |    0.12 | 15000.0000 | 5000.0000 |         - | 98321.43 KB |        1.01 |
+|     JsonReaderBenchmark |      .NET 7.0 |       10000 | 435,829.0 us | 13,578.17 us | 39,392.74 us | 421,647.1 us |  1.14 |    0.15 | 14000.0000 | 7000.0000 | 1000.0000 | 83460.31 KB |        0.86 |
+| SystemTextJsonBenchmark |      .NET 7.0 |       10000 | 378,523.2 us | 12,743.50 us | 37,173.38 us | 362,073.7 us |  1.00 |    0.15 | 16000.0000 | 8000.0000 | 1000.0000 |  97462.8 KB |        1.00 |
+|     JsonReaderBenchmark | NativeAOT 7.0 |       10000 | 430,449.1 us | 16,561.16 us | 47,249.91 us | 412,971.2 us |  1.13 |    0.17 | 14000.0000 | 7000.0000 | 1000.0000 | 83462.89 KB |        0.86 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 |       10000 | 384,891.2 us | 14,468.88 us | 41,280.54 us | 367,407.8 us |  1.00 |    0.00 | 16000.0000 | 8000.0000 | 1000.0000 | 97462.79 KB |        1.00 |
 
   [GitHub REST API]: https://docs.github.com/en/rest/branches/branches#merge-a-branch

--- a/bench/README.md
+++ b/bench/README.md
@@ -89,39 +89,38 @@ When benchmarking deserialization a subset of an example payload from the
     Intel Core i7-1065G7 CPU 1.30GHz, 1 CPU, 8 logical and 4 physical cores
     .NET SDK=7.0.100
       [Host]     : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
-      Job-QOSTER : .NET 6.0.11 (6.0.1122.52304), X64 RyuJIT AVX2
-      Job-NCTTVP : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
-      Job-YSQJJI : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
+      Job-FRBYQO : .NET 6.0.11 (6.0.1122.52304), X64 RyuJIT AVX2
+      Job-FPUDIR : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
+      Job-MSXFTZ : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
 
-
-| Method                  | Runtime       | ObjectCount |          Mean |        Error |        StdDev |        Median | Ratio | RatioSD |      Gen0 |      Gen1 |     Gen2 |   Allocated | Alloc Ratio |
-| ----------------------- | ------------- | ----------- | ------------: | -----------: | ------------: | ------------: | ----: | ------: | --------: | --------: | -------: | ----------: | ----------: |
-| JsonReaderBenchmark     | .NET 6.0      | 10          |     202.34 us |    20.552 us |     60.598 us |     190.91 us |  1.99 |    0.64 |    2.4414 |         - |        - |    11.41 KB |        0.67 |
-| SystemTextJsonBenchmark | .NET 6.0      | 10          |     117.39 us |     4.646 us |     13.553 us |     113.90 us |  1.13 |    0.17 |    4.1504 |    0.2441 |        - |    17.25 KB |        1.02 |
-| JsonReaderBenchmark     | .NET 7.0      | 10          |     112.36 us |     3.832 us |     11.118 us |     110.38 us |  1.08 |    0.17 |    2.6855 |         - |        - |    11.41 KB |        0.67 |
-| SystemTextJsonBenchmark | .NET 7.0      | 10          |      98.76 us |     2.991 us |      8.773 us |      96.94 us |  0.95 |    0.14 |    4.1504 |         - |        - |    16.97 KB |        1.00 |
-| JsonReaderBenchmark     | NativeAOT 7.0 | 10          |     168.08 us |    25.396 us |     74.880 us |     132.77 us |  1.63 |    0.68 |    2.4414 |         - |        - |    11.41 KB |        0.67 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 | 10          |     105.50 us |     4.485 us |     12.797 us |     104.44 us |  1.00 |    0.00 |    4.1504 |         - |        - |    16.97 KB |        1.00 |
-|                         |               |             |               |              |               |               |       |         |           |           |          |             |             |
-| JsonReaderBenchmark     | .NET 6.0      | 100         |   1,240.36 us |    36.970 us |    106.667 us |   1,196.85 us |  1.08 |    0.15 |   25.3906 |    7.8125 |        - |   111.67 KB |        0.69 |
-| SystemTextJsonBenchmark | .NET 6.0      | 100         |   1,144.78 us |    37.520 us |    108.255 us |   1,109.01 us |  1.00 |    0.13 |   37.1094 |   11.7188 |        - |   164.66 KB |        1.02 |
-| JsonReaderBenchmark     | .NET 7.0      | 100         |   1,185.21 us |    40.298 us |    114.973 us |   1,145.08 us |  1.04 |    0.17 |   25.3906 |    7.8125 |        - |   111.67 KB |        0.69 |
-| SystemTextJsonBenchmark | .NET 7.0      | 100         |   1,109.15 us |    35.183 us |    102.073 us |   1,068.34 us |  0.97 |    0.14 |   35.1563 |    9.7656 |        - |   161.56 KB |        1.00 |
-| JsonReaderBenchmark     | NativeAOT 7.0 | 100         |   1,114.53 us |    29.102 us |     80.156 us |   1,083.46 us |  0.97 |    0.13 |   23.4375 |    7.8125 |        - |   111.67 KB |        0.69 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 | 100         |   1,159.15 us |    52.550 us |    153.290 us |   1,103.81 us |  1.00 |    0.00 |   33.2031 |    9.7656 |        - |   161.56 KB |        1.00 |
-|                         |               |             |               |              |               |               |       |         |           |           |          |             |             |
-| JsonReaderBenchmark     | .NET 6.0      | 1000        |  13,449.47 us |   462.489 us |  1,341.763 us |  13,214.85 us |  0.95 |    0.15 |  171.8750 |   78.1250 |        - |  1110.12 KB |        0.70 |
-| SystemTextJsonBenchmark | .NET 6.0      | 1000        |  15,895.95 us |   942.387 us |  2,748.988 us |  15,849.49 us |  1.13 |    0.27 |  250.0000 |  125.0000 |        - |  1619.96 KB |        1.02 |
-| JsonReaderBenchmark     | .NET 7.0      | 1000        |  15,377.16 us |   479.259 us |  1,320.019 us |  15,327.51 us |  1.08 |    0.17 |  171.8750 |  156.2500 |        - |  1110.12 KB |        0.70 |
-| SystemTextJsonBenchmark | .NET 7.0      | 1000        |  14,739.72 us |   508.641 us |  1,459.387 us |  14,526.50 us |  1.04 |    0.15 |  250.0000 |  234.3750 |        - |  1588.75 KB |        1.00 |
-| JsonReaderBenchmark     | NativeAOT 7.0 | 1000        |  18,554.27 us | 1,701.470 us |  4,963.269 us |  16,851.99 us |  1.32 |    0.40 |  171.8750 |  156.2500 |        - |  1110.12 KB |        0.70 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 | 1000        |  14,366.94 us |   629.301 us |  1,835.700 us |  13,511.67 us |  1.00 |    0.00 |  250.0000 |  218.7500 |        - |  1588.76 KB |        1.00 |
-|                         |               |             |               |              |               |               |       |         |           |           |          |             |             |
-| JsonReaderBenchmark     | .NET 6.0      | 10000       | 168,778.99 us | 6,104.380 us | 17,903.090 us | 160,740.15 us |  1.20 |    0.19 | 2000.0000 | 1000.0000 | 250.0000 | 11194.13 KB |        0.68 |
-| SystemTextJsonBenchmark | .NET 6.0      | 10000       | 168,772.76 us | 6,891.284 us | 20,102.200 us | 159,809.92 us |  1.19 |    0.21 | 2500.0000 | 1000.0000 |        - | 16672.09 KB |        1.02 |
-| JsonReaderBenchmark     | .NET 7.0      | 10000       | 131,258.49 us | 3,662.383 us | 10,148.446 us | 129,675.98 us |  0.93 |    0.12 | 2000.0000 | 1000.0000 | 250.0000 | 11194.13 KB |        0.68 |
-| SystemTextJsonBenchmark | .NET 7.0      | 10000       | 138,900.25 us | 5,720.888 us | 16,778.376 us | 133,623.48 us |  0.99 |    0.17 | 2500.0000 | 1250.0000 | 250.0000 | 16359.59 KB |        1.00 |
-| JsonReaderBenchmark     | NativeAOT 7.0 | 10000       | 130,683.21 us | 4,577.537 us | 13,207.241 us | 126,413.93 us |  0.93 |    0.15 | 2000.0000 | 1000.0000 | 250.0000 | 11194.13 KB |        0.68 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 | 10000       | 142,635.96 us | 6,687.071 us | 18,970.107 us | 135,900.80 us |  1.00 |    0.00 | 2500.0000 | 1250.0000 | 250.0000 |  16360.5 KB |        1.00 |
+|                  Method |       Runtime | ObjectCount |         Mean |        Error |        StdDev |       Median | Ratio | RatioSD |       Gen0 |      Gen1 |      Gen2 |   Allocated | Alloc Ratio |
+|------------------------ |-------------- |------------ |-------------:|-------------:|--------------:|-------------:|------:|--------:|-----------:|----------:|----------:|------------:|------------:|
+|     JsonReaderBenchmark |      .NET 6.0 |          10 |     430.4 us |     28.69 us |      83.68 us |     399.1 us |  1.47 |    0.35 |    20.5078 |    6.8359 |         - |     84.3 KB |        0.86 |
+| SystemTextJsonBenchmark |      .NET 6.0 |          10 |     342.9 us |     21.17 us |      60.41 us |     324.5 us |  1.16 |    0.23 |    23.9258 |    7.8125 |         - |     98.9 KB |        1.01 |
+|     JsonReaderBenchmark |      .NET 7.0 |          10 |     408.1 us |     18.34 us |      52.33 us |     394.3 us |  1.39 |    0.24 |    20.5078 |    6.8359 |         - |     84.3 KB |        0.86 |
+| SystemTextJsonBenchmark |      .NET 7.0 |          10 |     314.7 us |     14.64 us |      43.18 us |     306.6 us |  1.08 |    0.21 |    23.9258 |    7.8125 |         - |    98.07 KB |        1.00 |
+|     JsonReaderBenchmark | NativeAOT 7.0 |          10 |     398.1 us |     17.66 us |      49.82 us |     387.5 us |  1.35 |    0.24 |    20.5078 |    6.8359 |         - |     84.3 KB |        0.86 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 |          10 |     296.6 us |     12.51 us |      36.50 us |     286.7 us |  1.00 |    0.00 |    23.9258 |    7.8125 |         - |    98.07 KB |        1.00 |
+|                         |               |             |              |              |               |              |       |         |            |           |           |             |             |
+|     JsonReaderBenchmark |      .NET 6.0 |         100 |   6,259.1 us |    533.00 us |   1,546.33 us |   5,817.0 us |  1.48 |    0.51 |   125.0000 |   62.5000 |         - |   840.58 KB |        0.85 |
+| SystemTextJsonBenchmark |      .NET 6.0 |         100 |   3,492.2 us |    136.55 us |     400.47 us |   3,368.7 us |  0.83 |    0.25 |   156.2500 |   78.1250 |         - |   994.96 KB |        1.01 |
+|     JsonReaderBenchmark |      .NET 7.0 |         100 |   4,276.0 us |    154.20 us |     442.41 us |   4,196.1 us |  1.02 |    0.30 |   136.7188 |  132.8125 |         - |   840.57 KB |        0.85 |
+| SystemTextJsonBenchmark |      .NET 7.0 |         100 |   3,223.2 us |    122.33 us |     352.94 us |   3,149.5 us |  0.78 |    0.26 |   160.1563 |  156.2500 |         - |   986.39 KB |        1.00 |
+|     JsonReaderBenchmark | NativeAOT 7.0 |         100 |   4,150.3 us |    174.82 us |     509.97 us |   4,048.6 us |  0.98 |    0.29 |   132.8125 |  125.0000 |         - |   840.57 KB |        0.85 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 |         100 |   4,558.2 us |    472.24 us |   1,362.52 us |   4,660.4 us |  1.00 |    0.00 |   160.1563 |  156.2500 |         - |   986.39 KB |        1.00 |
+|                         |               |             |              |              |               |              |       |         |            |           |           |             |             |
+|     JsonReaderBenchmark |      .NET 6.0 |        1000 |  78,578.1 us |  2,843.35 us |   8,066.12 us |  77,615.7 us |  1.01 |    0.15 |  1428.5714 |  571.4286 |  142.8571 |  8400.03 KB |        0.86 |
+| SystemTextJsonBenchmark |      .NET 6.0 |        1000 |  69,825.7 us |  2,688.92 us |   7,801.03 us |  68,575.6 us |  0.89 |    0.13 |  1625.0000 |  625.0000 |  125.0000 |  9875.27 KB |        1.01 |
+|     JsonReaderBenchmark |      .NET 7.0 |        1000 |  82,837.1 us |  3,608.50 us |  10,236.71 us |  79,817.6 us |  1.06 |    0.18 |  1428.5714 |  714.2857 |  142.8571 |  8399.49 KB |        0.86 |
+| SystemTextJsonBenchmark |      .NET 7.0 |        1000 |  75,251.8 us |  2,680.40 us |   7,733.57 us |  73,726.0 us |  0.96 |    0.13 |  1750.0000 | 1000.0000 |  250.0000 |   9789.3 KB |        1.00 |
+|     JsonReaderBenchmark | NativeAOT 7.0 |        1000 |  86,595.5 us |  3,068.95 us |   8,755.89 us |  85,300.8 us |  1.11 |    0.16 |  1428.5714 |  714.2857 |  142.8571 |  8399.27 KB |        0.86 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 |        1000 |  79,225.8 us |  3,401.67 us |   9,538.64 us |  79,016.5 us |  1.00 |    0.00 |  1750.0000 | 1000.0000 |  250.0000 |  9789.97 KB |        1.00 |
+|                         |               |             |              |              |               |              |       |         |            |           |           |             |             |
+|     JsonReaderBenchmark |      .NET 6.0 |       10000 | 884,528.8 us | 35,333.94 us | 103,628.32 us | 869,597.0 us |  1.29 |    0.22 | 13000.0000 | 5000.0000 |         - | 84084.95 KB |        0.86 |
+| SystemTextJsonBenchmark |      .NET 6.0 |       10000 | 768,371.6 us | 38,170.42 us | 110,130.39 us | 753,314.5 us |  1.13 |    0.23 | 15000.0000 | 5000.0000 |         - | 98321.43 KB |        1.01 |
+|     JsonReaderBenchmark |      .NET 7.0 |       10000 | 818,645.8 us | 28,842.23 us |  82,753.76 us | 811,705.2 us |  1.19 |    0.16 | 14000.0000 | 7000.0000 | 1000.0000 |  84089.4 KB |        0.86 |
+| SystemTextJsonBenchmark |      .NET 7.0 |       10000 | 704,268.1 us | 23,270.90 us |  68,614.77 us | 700,178.7 us |  1.03 |    0.16 | 16000.0000 | 8000.0000 | 1000.0000 |  97463.8 KB |        1.00 |
+|     JsonReaderBenchmark | NativeAOT 7.0 |       10000 | 822,064.3 us | 31,849.32 us |  92,400.64 us | 821,875.3 us |  1.20 |    0.18 | 14000.0000 | 7000.0000 | 1000.0000 | 84088.01 KB |        0.86 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 |       10000 | 693,208.3 us | 26,231.06 us |  74,838.70 us | 692,791.7 us |  1.00 |    0.00 | 16000.0000 | 8000.0000 | 1000.0000 | 97469.13 KB |        1.00 |
 
   [GitHub REST API]: https://docs.github.com/en/rest/branches/branches#merge-a-branch


### PR DESCRIPTION
The GitHub API benchmark so far used only a subset of the entire response. With this PR, we start using the entire response, with the exception of an object that has 18 properties (while `Jacob` only supports 16).