### PR TITLE
Add `Let` extension

### DIFF
--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -206,6 +206,15 @@ public static partial class JsonReader
     public static IJsonReader<object> AsObject<T>(this IJsonReader<T> reader) =>
         from v in reader select (object)v;
 
+    public static IJsonReader<TResult> Let<T, TResult>(this IJsonReader<T> reader,
+                                                       Func<IJsonReader<T>, IJsonReader<TResult>> selector)
+    {
+        if (reader == null) throw new ArgumentNullException(nameof(reader));
+        if (selector == null) throw new ArgumentNullException(nameof(selector));
+
+        return selector(reader);
+    }
+
     public static IJsonReader<T> Or<T>(this IJsonReader<T> reader1, IJsonReader<T> reader2) =>
         Either(reader1, reader2, null);
 

--- a/tests/JsonReaderTests.cs
+++ b/tests/JsonReaderTests.cs
@@ -1025,4 +1025,37 @@ public class JsonReaderTests
         Assert.Equal(new object[] { "foo", "bar", new object[] { "baz", new object[] { new object[] { "qux" } } } },
                      result);
     }
+
+    [Fact]
+    public void Let_Throws_When_Reader_Is_Null()
+    {
+        var e = Assert.Throws<ArgumentNullException>(() =>
+            JsonReader.Let<int, object>(null!, delegate { throw new NotImplementedException(); }));
+
+        Assert.Equal("reader", e.ParamName);
+    }
+
+    [Fact]
+    public void Let_Throws_When_Selector_Is_Null()
+    {
+        var e = Assert.Throws<ArgumentNullException>(() =>
+            JsonReader.Int32().Let<int, object>(null!));
+
+        Assert.Equal("selector", e.ParamName);
+    }
+
+    [Fact]
+    public void Let_Returns_Select_That_Receives_Reader_Return()
+    {
+        var reader = JsonReader.Int32();
+
+        IJsonReader<int>? inputReader = null;
+        IJsonReader<object>? outputReader = null;
+
+        var result = reader.Let(it => outputReader = (inputReader = it).AsObject());
+
+        Assert.Same(reader, inputReader);
+        Assert.NotNull(result);
+        Assert.Same(outputReader, result);
+    }
 }


### PR DESCRIPTION
This PR adds a `Let` extension that allows a reader to be shared for the setting up (or mapping to another) reader.

```c#
var reader =
    JsonReader.Int32()
              .Validate(n => n is > 1 and <= 20)
              .Let(r => JsonReader.Tuple(r, r));

Console.WriteLine(reader.Read(@"[5, 10]"));

// Following throws: "Invalid JSON value. See token "Number" at offset 5."
Console.WriteLine(reader.Read(@"[25, 10]"));
```
