### PR TITLE
Remove the need to track peeked token

### DIFF
--- a/src/ArrayReadStateMachine.cs
+++ b/src/ArrayReadStateMachine.cs
@@ -10,7 +10,7 @@ using System.Text.Json;
 public record struct ArrayReadStateMachine
 {
     public enum State { Initial, ItemOrEnd, PendingItemRead, Done, Error }
-    public enum ReadResult { Error, Incomplete, Item, Done }
+    public enum ReadResult { Error, Incomplete, BeginItem, Item, Done }
 
     public State CurrentState { get; private set; }
 
@@ -54,7 +54,7 @@ public record struct ArrayReadStateMachine
                     }
 
                     CurrentState = State.PendingItemRead;
-                    return ReadResult.Item;
+                    return ReadResult.BeginItem;
                 }
                 case State.PendingItemRead:
                 {

--- a/src/ArrayReadStateMachine.cs
+++ b/src/ArrayReadStateMachine.cs
@@ -27,7 +27,7 @@ public record struct ArrayReadStateMachine
             {
                 case State.Initial:
                 {
-                    if (!reader.Read())
+                    if (reader.TokenType is JsonTokenType.None && !reader.Read())
                         return ReadResult.Incomplete;
 
                     if (reader.TokenType is not JsonTokenType.StartArray)
@@ -41,16 +41,18 @@ public record struct ArrayReadStateMachine
                 }
                 case State.ItemOrEnd:
                 {
-                    if (!reader.Read())
+                    var lookahead = reader;
+
+                    if (!lookahead.Read())
                         return ReadResult.Incomplete;
 
-                    if (reader.TokenType is JsonTokenType.EndArray)
+                    if (lookahead.TokenType is JsonTokenType.EndArray)
                     {
+                        reader = lookahead;
                         CurrentState = State.Done;
                         return ReadResult.Done;
                     }
 
-                    reader.AssumeTokenRead();
                     CurrentState = State.PendingItemRead;
                     return ReadResult.Item;
                 }

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -139,6 +139,7 @@ public static partial class JsonReader
 
         var state = new JsonReaderState();
         var ar = new ArrayReadStateMachine();
+        var isReadingItem = false;
         ArrayReadStateMachine.ReadResult readResult;
 
         do
@@ -175,6 +176,13 @@ public static partial class JsonReader
                     }
                     case ArrayReadStateMachine.ReadResult.Item:
                     {
+                        if (!isReadingItem)
+                        {
+                            var read = rdr.Read();
+                            Debug.Assert(read);
+                            isReadingItem = true;
+                        }
+
                         switch (reader.TryRead(ref rdr))
                         {
                             case var r when r.IsIncomplete():
@@ -183,6 +191,7 @@ public static partial class JsonReader
                                 throw new JsonException(error);
                             case { Value: { } value }:
                                 ar.OnItemRead();
+                                isReadingItem = false;
                                 item = value;
                                 readResult = ArrayReadStateMachine.ReadResult.Item;
                                 goto exit;
@@ -212,54 +221,46 @@ public static partial class JsonReader
     }
 
     public static IJsonReader<T> Error<T>(string message) =>
-        Create<T>((ref Utf8JsonReader _) => Error(message));
+        CreatePure<T>((ref Utf8JsonReader _) => Error(message));
 
     static IJsonReader<string>? stringReader;
 
     public static IJsonReader<string> String() =>
         stringReader ??=
             Create(static (ref Utf8JsonReader rdr) =>
-                !rdr.Read()
-                    ? JsonReadError.Incomplete
-                    : rdr.TokenType == JsonTokenType.String
-                        ? Value(rdr.GetString()!)
-                        : Error("Invalid JSON value where a JSON string was expected."));
+                rdr.TokenType is JsonTokenType.String
+                ? Value(rdr.GetString()!)
+                : Error("Invalid JSON value where a JSON string was expected."));
 
     static IJsonReader<Guid>? guidReader;
 
     public static IJsonReader<Guid> Guid() =>
         guidReader ??=
             Create(static (ref Utf8JsonReader rdr) =>
-                !rdr.Read()
-                    ? JsonReadError.Incomplete
-                    : rdr.TokenType == JsonTokenType.String && rdr.TryGetGuid(out var value)
-                        ? Value(value)
-                        : Error("Invalid JSON value where a Guid was expected in the 'D' format (hyphen-separated)."));
+                rdr.TokenType is JsonTokenType.String && rdr.TryGetGuid(out var value)
+                ? Value(value)
+                : Error("Invalid JSON value where a Guid was expected in the 'D' format (hyphen-separated)."));
 
     static IJsonReader<bool>? booleanReader;
 
     public static IJsonReader<bool> Boolean() =>
         booleanReader ??=
             Create(static (ref Utf8JsonReader rdr) =>
-                !rdr.Read()
-                    ? JsonReadError.Incomplete
-                    : rdr.TokenType switch
-                      {
-                          JsonTokenType.True => Value(true),
-                          JsonTokenType.False => Value(false),
-                          _ => Error("Invalid JSON value where a JSON Boolean was expected.")
-                      });
+                rdr.TokenType switch
+                {
+                    JsonTokenType.True => Value(true),
+                    JsonTokenType.False => Value(false),
+                    _ => Error("Invalid JSON value where a JSON Boolean was expected.")
+                });
 
     static IJsonReader<DateTime>? dateTimeReader;
 
     public static IJsonReader<DateTime> DateTime() =>
         dateTimeReader ??=
             Create(static (ref Utf8JsonReader rdr) =>
-                !rdr.Read()
-                    ? JsonReadError.Incomplete
-                    : rdr.TokenType == JsonTokenType.String && rdr.TryGetDateTime(out var value)
-                        ? Value(value)
-                        : Error("JSON value cannot be interpreted as a date and time in ISO 8601-1 extended format."));
+                rdr.TokenType is JsonTokenType.String && rdr.TryGetDateTime(out var value)
+                ? Value(value)
+                : Error("JSON value cannot be interpreted as a date and time in ISO 8601-1 extended format."));
 
     public static IJsonReader<DateTime> DateTime(string format, IFormatProvider? provider) =>
         DateTime(format, provider, DateTimeStyles.None);
@@ -272,19 +273,15 @@ public static partial class JsonReader
     public static IJsonReader<DateTimeOffset> DateTimeOffset() =>
         dateTimeOffsetReader ??=
             Create(static (ref Utf8JsonReader rdr) =>
-                !rdr.Read()
-                    ? JsonReadError.Incomplete
-                    : rdr.TokenType == JsonTokenType.String && rdr.TryGetDateTimeOffset(out var value)
-                        ? Value(value)
-                        : Error("JSON value cannot be interpreted as a date and time offset in ISO 8601-1 extended format."));
+                rdr.TokenType is JsonTokenType.String && rdr.TryGetDateTimeOffset(out var value)
+                ? Value(value)
+                : Error("JSON value cannot be interpreted as a date and time offset in ISO 8601-1 extended format."));
 
     public static IJsonReader<T> Null<T>(T @null) =>
         Create((ref Utf8JsonReader rdr) =>
-            !rdr.Read()
-                ? JsonReadError.Incomplete
-                : rdr.TokenType == JsonTokenType.Null
-                    ? Value(@null)
-                    : Error("Invalid JSON value where a JSON null was expected."));
+            rdr.TokenType is JsonTokenType.Null
+            ? Value(@null)
+            : Error("Invalid JSON value where a JSON null was expected."));
 
     static bool IsEnumDefined<T>(T value) where T : struct, Enum =>
 #if NET5_0_OR_GREATER
@@ -393,26 +390,24 @@ public static partial class JsonReader
                 Debug.Assert(frame == BufferFrame);
             }
 
-            var bookmark = rdr;
-            var read = rdr.Read();
-
-            if (!read)
-            {
-                rdr = bookmark;
-                return rdr.Suspend(BufferFrame);
-            }
-
             switch (rdr.TokenType)
             {
                 case JsonTokenType.Null or JsonTokenType.False or JsonTokenType.True
                     or JsonTokenType.Number or JsonTokenType.String:
                 {
-                    rdr.AssumeTokenRead();
                     return reader.TryRead(ref rdr);
                 }
                 case JsonTokenType.StartObject or JsonTokenType.StartArray:
                 {
                     var depth = rdr.CurrentDepth;
+                    var bookmark = rdr;
+                    if (!rdr.Read())
+                    {
+                        rdr = bookmark;
+                        return rdr.Suspend(BufferFrame);
+                    }
+
+                    bool read;
                     do
                     {
                         read = rdr.Read();
@@ -462,11 +457,12 @@ public static partial class JsonReader
 
     public static IJsonReader<TResult> Object<T, TResult>(IJsonReader<T> reader,
                                                           Func<List<KeyValuePair<string, T>>, TResult> resultSelector) =>
-        Create((ref Utf8JsonReader rdr) =>
+        CreatePure((ref Utf8JsonReader rdr) =>
         {
-            if (!rdr.TryReadToken(out var tokenType))
+            if (rdr.TokenType is JsonTokenType.None && !rdr.Read())
                 throw PartialJsonNotSupportedException();
 
+            var tokenType = rdr.TokenType;
             if (tokenType is not JsonTokenType.StartObject)
                 return Error("Invalid JSON value where a JSON object was expected.");
 
@@ -480,7 +476,11 @@ public static partial class JsonReader
                 if (tokenType is JsonTokenType.EndObject)
                     break;
 
+                Debug.Assert(rdr.TokenType is JsonTokenType.PropertyName);
                 var name = rdr.GetString()!;
+
+                if (!rdr.Read())
+                    throw PartialJsonNotSupportedException();
 
                 switch (reader.TryRead(ref rdr))
                 {
@@ -525,11 +525,12 @@ public static partial class JsonReader
             IJsonProperty<T13, JsonReadResult<T13>> property13, IJsonProperty<T14, JsonReadResult<T14>> property14,
             IJsonProperty<T15, JsonReadResult<T15>> property15, IJsonProperty<T16, JsonReadResult<T16>> property16,
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> projector) =>
-        Create((ref Utf8JsonReader reader) =>
+        CreatePure((ref Utf8JsonReader reader) =>
         {
-            if (!reader.TryReadToken(out var tokenType))
+            if (reader.TokenType is JsonTokenType.None && !reader.Read())
                 throw PartialJsonNotSupportedException();
 
+            var tokenType = reader.TokenType;
             if (tokenType is not JsonTokenType.StartObject)
                 return Error("Invalid JSON value where a JSON object was expected.");
 
@@ -560,6 +561,8 @@ public static partial class JsonReader
                 if (tokenType is JsonTokenType.EndObject)
                     break;
 
+                Debug.Assert(reader.TokenType is JsonTokenType.PropertyName);
+
                 if (ReadPropertyValue(property1, ref reader, ref value1, ref error)) continue; if (error is not null) return Error(error);
                 if (ReadPropertyValue(property2, ref reader, ref value2, ref error)) continue; if (error is not null) return Error(error);
                 if (ReadPropertyValue(property3, ref reader, ref value3, ref error)) continue; if (error is not null) return Error(error);
@@ -589,6 +592,9 @@ public static partial class JsonReader
                 {
                     if (!property.IsMatch(ref reader))
                         return false;
+
+                    if (!reader.Read())
+                        throw PartialJsonNotSupportedException();
 
                     switch (property.Reader.TryRead(ref reader))
                     {
@@ -649,14 +655,14 @@ public static partial class JsonReader
                                                          Func<List<T>, TResult> resultSelector) =>
         Create((ref Utf8JsonReader rdr) =>
         {
-            var (sm, list) =
-                rdr.IsResuming && ((ArrayReadStateMachine, List<T>))rdr.Pop() is var ps
+            var (sm, isReadingItem, list) =
+                rdr.IsResuming && ((ArrayReadStateMachine, bool, List<T>))rdr.Pop() is var ps
                     ? ps
                     : default;
 
-            return Read(ref rdr, sm, list);
+            return Read(ref rdr, sm, isReadingItem, list);
 
-            JsonReadResult<TResult> Read(ref Utf8JsonReader rdr, ArrayReadStateMachine sm, List<T>? list)
+            JsonReadResult<TResult> Read(ref Utf8JsonReader rdr, ArrayReadStateMachine sm, bool isReadingItem, List<T>? list)
             {
                 while (true)
                 {
@@ -666,23 +672,31 @@ public static partial class JsonReader
                             return Error("Invalid JSON value where a JSON array was expected.");
 
                         case ArrayReadStateMachine.ReadResult.Incomplete:
-                            return rdr.Suspend((sm, list));
+                            return rdr.Suspend((sm, isReadingItem, list));
 
                         case ArrayReadStateMachine.ReadResult.Done:
                             return Value(resultSelector(list ?? new List<T>()));
 
                         case ArrayReadStateMachine.ReadResult.Item:
                         {
+                            if (!isReadingItem)
+                            {
+                                var read = rdr.Read();
+                                Debug.Assert(read);
+                                isReadingItem = true;
+                            }
+
                             switch (itemReader.TryRead(ref rdr))
                             {
                                 case var r when r.IsIncomplete():
-                                    return rdr.Suspend((sm, list));
+                                    return rdr.Suspend((sm, isReadingItem, list));
                                 case { Error: { } error }:
                                     return Error(error);
                                 case { Value: var item }:
                                     list ??= new List<T>();
                                     list.Add(item);
                                     sm.OnItemRead();
+                                    isReadingItem = false;
                                     break;
                             }
                             break;
@@ -723,6 +737,9 @@ public static partial class JsonReader
     static IJsonReader<T> Create<T>(Handler<T> handler) =>
         new DelegatingJsonReader<T>(handler);
 
+    static IJsonReader<T> CreatePure<T>(Handler<T> handler) =>
+        new DelegatingJsonReader<T>(handler, pure: true);
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static JsonReadResult<T> Value<T>(T value) => JsonReadResult.Value(value);
 
@@ -734,11 +751,19 @@ public static partial class JsonReader
     sealed class DelegatingJsonReader<T> : IJsonReader<T>
     {
         readonly Handler<T> handler;
+        readonly bool pure;
 
-        public DelegatingJsonReader(Handler<T> handler) => this.handler = handler;
+        public DelegatingJsonReader(Handler<T> handler, bool pure = false)
+        {
+            this.handler = handler;
+            this.pure = pure;
+        }
 
         public JsonReadResult<T> TryRead(ref Utf8JsonReader reader)
         {
+            if (!this.pure && reader.TokenType is JsonTokenType.None && !reader.Read())
+                return JsonReadError.Incomplete;
+
             var (value, error) = this.handler(ref reader);
             if (error is not null)
                 return new JsonReadError(error);

--- a/src/JsonReader.g.tt
+++ b/src/JsonReader.g.tt
@@ -38,11 +38,9 @@ partial class JsonReader
     public static IJsonReader<<#= e.Native #>> <#= e.Api #>() =>
         <#= e.Native #>Reader ??=
             Create(static (ref Utf8JsonReader rdr) =>
-                !rdr.Read()
-                    ? JsonReadError.Incomplete
-                    : rdr.TokenType == JsonTokenType.Number && rdr.TryGet<#= e.Api #>(out var value)
-                    ? Value(value)
-                    : Error("Invalid JSON value; expecting a JSON number compatible with <#= e.Api #>."));
+                rdr.TokenType is JsonTokenType.Number && rdr.TryGet<#= e.Api #>(out var value)
+                ? Value(value)
+                : Error("Invalid JSON value; expecting a JSON number compatible with <#= e.Api #>."));
 <#
     }
 }
@@ -93,16 +91,19 @@ partial class JsonReader
         Tuple<<#= ts #>>(
             <#= string.Join(@",
             ", from n in ns select "IJsonReader<T" + n + "> item" + n + "Reader") #>) =>
-        Create((ref Utf8JsonReader rdr) =>
+        CreatePure((ref Utf8JsonReader rdr) =>
         {
-            if (!rdr.Read())
+            if (rdr.TokenType is JsonTokenType.None && !rdr.Read())
                 throw PartialJsonNotSupportedException();
 
-            if (rdr.TokenType != JsonTokenType.StartArray)
+            if (rdr.TokenType is not JsonTokenType.StartArray)
                 return Error("Invalid JSON value where a JSON array was expected.");
 <#
         foreach (var n in ns)
         { #>
+
+            if (!rdr.Read())
+                throw PartialJsonNotSupportedException();
 
             T<#= n #> item<#= n #>;
             switch(item<#= n #>Reader.TryRead(ref rdr))
@@ -117,7 +118,7 @@ partial class JsonReader
             if (!rdr.Read())
                 throw PartialJsonNotSupportedException();
 
-            if (rdr.TokenType != JsonTokenType.EndArray)
+            if (rdr.TokenType is not JsonTokenType.EndArray)
                 return Error("Invalid JSON value; JSON array has too many values.");
 
             return Value((<#= string.Join(", ", from n in ns select "item" + n) #>));

--- a/src/Utf8JsonReader.cs
+++ b/src/Utf8JsonReader.cs
@@ -8,7 +8,6 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Text.Json;
 
 #pragma warning disable CA1815 // Override equals and operator equals on value types

--- a/tests/ArrayReadStateMachineTests.cs
+++ b/tests/ArrayReadStateMachineTests.cs
@@ -204,10 +204,15 @@ public class ArrayReadStateMachineTests
 
             if (result is ReadResult.Item)
             {
-                var read = reader.TokenType is JsonTokenType.StartObject or JsonTokenType.StartArray
-                         ? reader.TrySkip()
-                         : reader.Read();
+                var read = reader.Read();
                 Assert.True(read);
+
+                if (reader.TokenType is JsonTokenType.StartObject or JsonTokenType.StartArray)
+                {
+                    var skipped = reader.TrySkip();
+                    Assert.True(skipped);
+                }
+
                 subject.OnItemRead();
                 Assert.Equal(State.ItemOrEnd, subject.CurrentState);
             }

--- a/tests/ArrayReadStateMachineTests.cs
+++ b/tests/ArrayReadStateMachineTests.cs
@@ -5,6 +5,7 @@
 namespace Jacob.Tests;
 
 using System;
+using System.Linq;
 using System.Text;
 using Xunit;
 using MoreLinq;
@@ -15,10 +16,12 @@ using State = ArrayReadStateMachine.State;
 public class ArrayReadStateMachineTests
 {
     [Fact]
-    public void Default_Instance_CurrentState_Is_Initialized()
+    public void Default_Instance_Is_Initialized()
     {
         var subject = new ArrayReadStateMachine();
         Assert.Equal(State.Initial, subject.CurrentState);
+        Assert.Equal(0, subject.CurrentLength);
+        Assert.Equal(0, subject.CurrentItemLoopCount);
     }
 
     [Fact]
@@ -74,135 +77,166 @@ public class ArrayReadStateMachineTests
         _ = Assert.IsType<InvalidOperationException>(ex);
     }
 
-    public static readonly TheoryData<string[], (ReadResult, State)[]> Read_Reads_Array_Data =
+    [Fact]
+    public void Read_Increments_CurrentItemLoopCount_When_Current_State_Is_PendingItemRead()
+    {
+        var subject = new ArrayReadStateMachine();
+        var reader = new Utf8JsonReader("[{"u8, isFinalBlock: false, new());
+
+        foreach (var i in Enumerable.Range(0, 10))
+        {
+            var result = subject.Read(ref reader);
+
+            Assert.Equal(ReadResult.Item, result);
+            Assert.Equal(State.PendingItemRead, subject.CurrentState);
+            Assert.Equal(0, subject.CurrentLength);
+            Assert.Equal(i, subject.CurrentItemLoopCount);
+        }
+    }
+
+    public static readonly TheoryData<string[], (ReadResult, int, State)[]> Read_Reads_Array_Data =
         new()
         {
             {
                 Array.Empty<string>(),
                 new[]
                 {
-                    (ReadResult.Incomplete, State.Initial),
+                    (ReadResult.Incomplete, 0, State.Initial),
                 }
             },
             {
                 new[] { "[" },
                 new[]
                 {
-                    (ReadResult.Incomplete, State.ItemOrEnd),
+                    (ReadResult.Incomplete, 0, State.ItemOrEnd),
                 }
             },
             {
                 new[] { "[", "]" },
                 new[]
                 {
-                    (ReadResult.Incomplete, State.ItemOrEnd),
-                    (ReadResult.Done, State.Done)
+                    (ReadResult.Incomplete, 0, State.ItemOrEnd),
+                    (ReadResult.Done, 0, State.Done)
                 }
             },
             {
                 new[] { "[]" },
                 new[]
                 {
-                    (ReadResult.Done, State.Done)
+                    (ReadResult.Done, 0, State.Done)
                 }
             },
             {
                 new[] { "[", "null", "]" },
                 new[]
                 {
-                    (ReadResult.Incomplete, State.ItemOrEnd),
-                    (ReadResult.BeginItem, State.PendingItemRead),
-                    (ReadResult.Done, State.Done)
+                    (ReadResult.Incomplete, 0, State.ItemOrEnd),
+                    (ReadResult.Item, 1, State.PendingItemRead),
+                    (ReadResult.Done, 1, State.Done)
                 }
             },
             {
                 new[] { "[", "nu", "ll", "]" },
                 new[]
                 {
-                    (ReadResult.Incomplete, State.ItemOrEnd),
-                    (ReadResult.Incomplete, State.ItemOrEnd),
-                    (ReadResult.BeginItem, State.PendingItemRead),
-                    (ReadResult.Done, State.Done)
+                    (ReadResult.Incomplete, 0, State.ItemOrEnd),
+                    (ReadResult.Incomplete, 0, State.ItemOrEnd),
+                    (ReadResult.Item, 1, State.PendingItemRead),
+                    (ReadResult.Done, 1, State.Done)
+                }
+            },
+            {
+                new[] { "[", "n", "u", "l", "l", "]" },
+                new[]
+                {
+                    (ReadResult.Incomplete, 0, State.ItemOrEnd),
+                    (ReadResult.Incomplete, 0, State.ItemOrEnd),
+                    (ReadResult.Incomplete, 0, State.ItemOrEnd),
+                    (ReadResult.Incomplete, 0, State.ItemOrEnd),
+                    (ReadResult.Item, 1, State.PendingItemRead),
+                    (ReadResult.Done, 1, State.Done)
                 }
             },
             {
                 new[] { "[", "nu", "ll]" },
                 new[]
                 {
-                    (ReadResult.Incomplete, State.ItemOrEnd),
-                    (ReadResult.Incomplete, State.ItemOrEnd),
-                    (ReadResult.BeginItem, State.PendingItemRead),
-                    (ReadResult.Done, State.Done)
+                    (ReadResult.Incomplete, 0, State.ItemOrEnd),
+                    (ReadResult.Incomplete, 0, State.ItemOrEnd),
+                    (ReadResult.Item, 1, State.PendingItemRead),
+                    (ReadResult.Done, 1, State.Done)
                 }
             },
             {
                 new[] { "[", "123", "]" },
                 new[]
                 {
-                    (ReadResult.Incomplete, State.ItemOrEnd),
-                    (ReadResult.Incomplete, State.ItemOrEnd),
-                    (ReadResult.BeginItem, State.PendingItemRead),
-                    (ReadResult.Done, State.Done)
+                    (ReadResult.Incomplete, 0, State.ItemOrEnd),
+                    (ReadResult.Incomplete, 0, State.ItemOrEnd),
+                    (ReadResult.Item, 1, State.PendingItemRead),
+                    (ReadResult.Done, 1, State.Done)
                 }
             },
             {
                 new[] { "[", "null", ",", "true", ", false", "]" },
                 new[]
                 {
-                    (ReadResult.Incomplete, State.ItemOrEnd),
-                    (ReadResult.BeginItem, State.PendingItemRead),
-                    (ReadResult.Incomplete, State.ItemOrEnd),
-                    (ReadResult.BeginItem, State.PendingItemRead),
-                    (ReadResult.BeginItem, State.PendingItemRead),
-                    (ReadResult.Done, State.Done)
+                    (ReadResult.Incomplete, 0, State.ItemOrEnd),
+                    (ReadResult.Item, 1, State.PendingItemRead),
+                    (ReadResult.Incomplete, 0, State.ItemOrEnd),
+                    (ReadResult.Item, 2, State.PendingItemRead),
+                    (ReadResult.Item, 3, State.PendingItemRead),
+                    (ReadResult.Done, 3, State.Done)
                 }
             },
             {
                 new[] { "[[]]" },
                 new[]
                 {
-                    (ReadResult.BeginItem, State.PendingItemRead),
-                    (ReadResult.Done, State.Done)
+                    (ReadResult.Item, 1, State.PendingItemRead),
+                    (ReadResult.Done, 1, State.Done)
                 }
             },
             {
                 new[] { "[[], {}]" },
                 new[]
                 {
-                    (ReadResult.BeginItem, State.PendingItemRead),
-                    (ReadResult.BeginItem, State.PendingItemRead),
-                    (ReadResult.Done, State.Done)
+                    (ReadResult.Item, 1, State.PendingItemRead),
+                    (ReadResult.Item, 2, State.PendingItemRead),
+                    (ReadResult.Done, 2, State.Done)
                 }
             },
             {
                 new[] { "[[], ", /*lang=json*/"""{ "x": 123, "y": 456 }""", "]"},
                 new[]
                 {
-                    (ReadResult.BeginItem, State.PendingItemRead),
-                    (ReadResult.BeginItem, State.PendingItemRead),
-                    (ReadResult.Done, State.Done)
+                    (ReadResult.Item, 1, State.PendingItemRead),
+                    (ReadResult.Item, 2, State.PendingItemRead),
+                    (ReadResult.Done, 2, State.Done)
                 }
             },
         };
 
     [Theory]
     [MemberData(nameof(Read_Reads_Array_Data))]
-    public void Read_Reads_Array(string[] chunks, (ReadResult, State)[] expectations)
+    public void Read_Reads_Array(string[] chunks, (ReadResult, int, State)[] expectations)
     {
         var subject = new ArrayReadStateMachine();
         var jsonReaderState = new JsonReaderState();
 
         var chunkRun = string.Empty;
-        foreach (var (chunk, (expectedResult, expectedState)) in chunks.ZipLongest(expectations, ValueTuple.Create))
+        foreach (var (thisChunk, (expectedResult, expectedLength, expectedState)) in
+                 chunks.ZipLongest(expectations, ValueTuple.Create))
         {
-            var chunkSpan = Encoding.UTF8.GetBytes(chunkRun + chunk);
+            var chunk = chunkRun + thisChunk;
+            var chunkSpan = Encoding.UTF8.GetBytes(chunk).AsSpan();
             var reader = new Utf8JsonReader(chunkSpan, false, jsonReaderState);
             var result = subject.Read(ref reader);
 
             Assert.Equal(expectedResult, result);
             Assert.Equal(expectedState, subject.CurrentState);
 
-            if (result is ReadResult.BeginItem)
+            if (result is ReadResult.Item)
             {
                 var read = reader.Read();
                 Assert.True(read);
@@ -214,11 +248,11 @@ public class ArrayReadStateMachineTests
                 }
 
                 subject.OnItemRead();
+                Assert.Equal(expectedLength, subject.CurrentLength);
                 Assert.Equal(State.ItemOrEnd, subject.CurrentState);
             }
 
-            var chunkTail = Encoding.UTF8.GetString(chunkSpan[(int)reader.BytesConsumed..]);
-            chunkRun = result is ReadResult.Incomplete ? chunkRun + chunkTail : chunkTail;
+            chunkRun = Encoding.UTF8.GetString(chunkSpan[(int)reader.BytesConsumed..]);
             jsonReaderState = reader.CurrentState;
         }
 

--- a/tests/ArrayReadStateMachineTests.cs
+++ b/tests/ArrayReadStateMachineTests.cs
@@ -111,7 +111,7 @@ public class ArrayReadStateMachineTests
                 new[]
                 {
                     (ReadResult.Incomplete, State.ItemOrEnd),
-                    (ReadResult.Item, State.PendingItemRead),
+                    (ReadResult.BeginItem, State.PendingItemRead),
                     (ReadResult.Done, State.Done)
                 }
             },
@@ -121,7 +121,7 @@ public class ArrayReadStateMachineTests
                 {
                     (ReadResult.Incomplete, State.ItemOrEnd),
                     (ReadResult.Incomplete, State.ItemOrEnd),
-                    (ReadResult.Item, State.PendingItemRead),
+                    (ReadResult.BeginItem, State.PendingItemRead),
                     (ReadResult.Done, State.Done)
                 }
             },
@@ -131,7 +131,7 @@ public class ArrayReadStateMachineTests
                 {
                     (ReadResult.Incomplete, State.ItemOrEnd),
                     (ReadResult.Incomplete, State.ItemOrEnd),
-                    (ReadResult.Item, State.PendingItemRead),
+                    (ReadResult.BeginItem, State.PendingItemRead),
                     (ReadResult.Done, State.Done)
                 }
             },
@@ -141,7 +141,7 @@ public class ArrayReadStateMachineTests
                 {
                     (ReadResult.Incomplete, State.ItemOrEnd),
                     (ReadResult.Incomplete, State.ItemOrEnd),
-                    (ReadResult.Item, State.PendingItemRead),
+                    (ReadResult.BeginItem, State.PendingItemRead),
                     (ReadResult.Done, State.Done)
                 }
             },
@@ -150,10 +150,10 @@ public class ArrayReadStateMachineTests
                 new[]
                 {
                     (ReadResult.Incomplete, State.ItemOrEnd),
-                    (ReadResult.Item, State.PendingItemRead),
+                    (ReadResult.BeginItem, State.PendingItemRead),
                     (ReadResult.Incomplete, State.ItemOrEnd),
-                    (ReadResult.Item, State.PendingItemRead),
-                    (ReadResult.Item, State.PendingItemRead),
+                    (ReadResult.BeginItem, State.PendingItemRead),
+                    (ReadResult.BeginItem, State.PendingItemRead),
                     (ReadResult.Done, State.Done)
                 }
             },
@@ -161,7 +161,7 @@ public class ArrayReadStateMachineTests
                 new[] { "[[]]" },
                 new[]
                 {
-                    (ReadResult.Item, State.PendingItemRead),
+                    (ReadResult.BeginItem, State.PendingItemRead),
                     (ReadResult.Done, State.Done)
                 }
             },
@@ -169,8 +169,8 @@ public class ArrayReadStateMachineTests
                 new[] { "[[], {}]" },
                 new[]
                 {
-                    (ReadResult.Item, State.PendingItemRead),
-                    (ReadResult.Item, State.PendingItemRead),
+                    (ReadResult.BeginItem, State.PendingItemRead),
+                    (ReadResult.BeginItem, State.PendingItemRead),
                     (ReadResult.Done, State.Done)
                 }
             },
@@ -178,8 +178,8 @@ public class ArrayReadStateMachineTests
                 new[] { "[[], ", /*lang=json*/"""{ "x": 123, "y": 456 }""", "]"},
                 new[]
                 {
-                    (ReadResult.Item, State.PendingItemRead),
-                    (ReadResult.Item, State.PendingItemRead),
+                    (ReadResult.BeginItem, State.PendingItemRead),
+                    (ReadResult.BeginItem, State.PendingItemRead),
                     (ReadResult.Done, State.Done)
                 }
             },
@@ -202,7 +202,7 @@ public class ArrayReadStateMachineTests
             Assert.Equal(expectedResult, result);
             Assert.Equal(expectedState, subject.CurrentState);
 
-            if (result is ReadResult.Item)
+            if (result is ReadResult.BeginItem)
             {
                 var read = reader.Read();
                 Assert.True(read);

--- a/tests/JsonReaderTests.cs
+++ b/tests/JsonReaderTests.cs
@@ -33,9 +33,10 @@ public abstract class JsonReaderTestsBase
     {
         var sentinel = $"END-{Guid.NewGuid()}";
         var rdr = new Utf8JsonReader(Encoding.UTF8.GetBytes($"""[{json}, "{sentinel}"]"""));
-        Assert.True(rdr.Read());
-        _ = reader.Read(ref rdr);
-        Assert.True(rdr.Read());
+        Assert.True(rdr.Read());  // array start
+        Assert.True(rdr.Read());  // position at first element
+        _ = reader.Read(ref rdr); // read it
+        Assert.True(rdr.Read());  // read next
         Assert.Equal(JsonTokenType.String, rdr.TokenType);
         Assert.Equal(sentinel, rdr.GetString());
     }

--- a/tests/StreamingTests.cs
+++ b/tests/StreamingTests.cs
@@ -37,15 +37,15 @@ public sealed class StreamingTests
         { JsonReader.Boolean().AsObject(), /*lang=json*/ "true", 5, new[] { 4 } },
         { JsonReader.Int32().AsObject(), /*lang=json*/ "12", 2, new[] { 0, 2 } },
         { JsonReader.Int32().AsObject(), /*lang=json*/ "12", 5, new[] { 0, 2 } },
-        { JsonReader.String().AsObject(), /*lang=json*/ """ "foo" """, 2, new[] { 0, 0, 6 } },
-        { JsonReader.String().AsObject(), /*lang=json*/ """ "foo" """, 5, new[] { 0, 6 } },
+        { JsonReader.String().AsObject(), /*lang=json*/ """ "foo" """, 2, new[] { 1, 0, 0, 5 } },
+        { JsonReader.String().AsObject(), /*lang=json*/ """ "foo" """, 5, new[] { 1, 5 } },
         { JsonReader.String().AsObject(), /*lang=json*/ """ "foo" """, 10, new[] { 6 } },
-        { NestedObjectReader.AsObject(), /*lang=json*/ """{ "prop1": { "prop2": "foo" } }""", 2, new[] { 0, 0, 0, 0, 31 } },
-        { NestedObjectReader.AsObject(), /*lang=json*/ """{ "prop1": { "prop2": "foo" } }""", 5, new[] { 0, 0, 0, 31 } },
-        { NestedObjectReader.AsObject(), /*lang=json*/ """{ "prop1": { "prop2": "foo" } }""", 10, new[] { 0, 0, 31 } },
-        { JsonReader.Array(JsonReader.String()).AsObject(), /*lang=json*/ """["foo", "bar", "baz"]""", 2, new[] { 0, 0, 0, 0, 21 } },
-        { JsonReader.Array(JsonReader.String()).AsObject(), /*lang=json*/ """["foo", "bar", "baz"]""", 5, new[] { 0, 0, 0, 21 } },
-        { JsonReader.Array(JsonReader.String()).AsObject(), /*lang=json*/ """["foo", "bar", "baz"]""", 10, new[] { 0, 0, 21 } },
+        { NestedObjectReader.AsObject(), /*lang=json*/ """{ "prop1": { "prop2": "foo" } }""", 2, new[] { 1, 0, 0, 0, 0, 30 } },
+        { NestedObjectReader.AsObject(), /*lang=json*/ """{ "prop1": { "prop2": "foo" } }""", 5, new[] { 1, 0, 0, 0, 30 } },
+        { NestedObjectReader.AsObject(), /*lang=json*/ """{ "prop1": { "prop2": "foo" } }""", 10, new[] { 1, 0, 0, 30 } },
+        { JsonReader.Array(JsonReader.String()).AsObject(), /*lang=json*/ """["foo", "bar", "baz"]""", 2, new[] { 1, 0, 0, 0, 0, 20 } },
+        { JsonReader.Array(JsonReader.String()).AsObject(), /*lang=json*/ """["foo", "bar", "baz"]""", 5, new[] { 1, 0, 0, 20 } },
+        { JsonReader.Array(JsonReader.String()).AsObject(), /*lang=json*/ """["foo", "bar", "baz"]""", 10, new[] { 1, 0, 20 } },
     };
 
     [Theory]


### PR DESCRIPTION
This PR removes the need for `AssumeTokenRead` on the wrapper `Utf8JsonReader`. As a result, the `Skip` and `TrySkip` methods become simple forwards to the inner reader.

The removal comes from changing JSON readers to be more aligned with how `Utf8JsonReader` behaves. When a reader reads a JSON value, it is no longer expected that the reader moves past the value. If a reader sees that `Utf8JsonReader.TokenType` is `JsonTokenType.None` then it assumes a freshly initialized `Utf8JsonReader` and will call `Read` on it. If it sees another token type then it will simply read it and leave the reader on the token. The exception to this rule is if the value is a JSON object or array. In those cases, the reader is left positioned on `JsonTokenType.EndObject` or `JsonTokenType.EndArray`, respectively.

There are two additional benefits of this change:

- Jacob's `Utf8JsonReader` is aligned with how the one from .NET behaves and can be used interchangeably.
- It may be possible to remove Jacob's `Utf8JsonReader` entirely in the future, if the stack in its reader state can be moved to a parameter of the `Read` method.