### PR TITLE
Partial reading for objects

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -16,71 +16,73 @@ In another configuration, we benchmark the worst-case scenario performance of
 `JsonReader.Either` by deserializing an array with elements of type
 `MultiPolygon`. We measure the following:
 
-    BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.819)
+    BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.963)
     Intel Core i7-1065G7 CPU 1.30GHz, 1 CPU, 8 logical and 4 physical cores
-    .NET SDK=7.0.100
-      [Host]     : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
-      Job-IBGVMK : .NET 6.0.11 (6.0.1122.52304), X64 RyuJIT AVX2
-      Job-TTWDSU : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
-      Job-XACLOO : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
+    .NET SDK=7.0.101
+      [Host]     : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT AVX2
+      Job-YZVNIW : .NET 6.0.12 (6.0.1222.56807), X64 RyuJIT AVX2
+      Job-MRCBRH : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT AVX2
+      Job-DTLXOA : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT AVX2
 
-| Method                  | Runtime       | ObjectCount | SampleSet    |          Mean |        Error |       StdDev | Ratio | RatioSD |      Gen0 |      Gen1 |      Gen2 |   Allocated | Alloc Ratio |
-| ----------------------- | ------------- | ----------- | ------------ | ------------: | -----------: | -----------: | ----: | ------: | --------: | --------: | --------: | ----------: | ----------: |
-| JsonReaderBenchmark     | .NET 6.0      | 10          | All          |      46.14 μs |     0.883 μs |     1.179 μs |  1.37 |    0.06 |    1.8921 |         - |         - |     7.83 KB |        0.50 |
-| SystemTextJsonBenchmark | .NET 6.0      | 10          | All          |      36.19 μs |     0.714 μs |     1.153 μs |  1.09 |    0.06 |    3.7842 |         - |         - |     15.7 KB |        1.00 |
-| JsonReaderBenchmark     | .NET 7.0      | 10          | All          |      45.87 μs |     0.907 μs |     2.155 μs |  1.37 |    0.09 |    1.8921 |         - |         - |     7.83 KB |        0.50 |
-| SystemTextJsonBenchmark | .NET 7.0      | 10          | All          |      34.14 μs |     0.676 μs |     1.805 μs |  1.02 |    0.06 |    3.8452 |         - |         - |    15.73 KB |        1.00 |
-| JsonReaderBenchmark     | NativeAOT 7.0 | 10          | All          |      45.52 μs |     0.910 μs |     1.011 μs |  1.36 |    0.05 |    1.8921 |         - |         - |     7.83 KB |        0.50 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 | 10          | All          |      33.32 μs |     0.661 μs |     1.364 μs |  1.00 |    0.00 |    3.8452 |         - |         - |    15.73 KB |        1.00 |
-|                         |               |             |              |               |              |              |       |         |           |           |           |             |             |
-| JsonReaderBenchmark     | .NET 6.0      | 10          | MultiPolygon |      99.51 μs |     1.948 μs |     3.089 μs |  1.19 |    0.08 |    4.8828 |    0.1221 |         - |    20.16 KB |        0.53 |
-| SystemTextJsonBenchmark | .NET 6.0      | 10          | MultiPolygon |      89.99 μs |     1.796 μs |     3.828 μs |  1.08 |    0.07 |    9.2773 |         - |         - |    38.02 KB |        1.00 |
-| JsonReaderBenchmark     | .NET 7.0      | 10          | MultiPolygon |      96.79 μs |     1.778 μs |     2.493 μs |  1.17 |    0.08 |    4.8828 |         - |         - |    20.16 KB |        0.53 |
-| SystemTextJsonBenchmark | .NET 7.0      | 10          | MultiPolygon |      83.68 μs |     1.667 μs |     4.421 μs |  1.01 |    0.07 |    9.2773 |    0.1221 |         - |    38.05 KB |        1.00 |
-| JsonReaderBenchmark     | NativeAOT 7.0 | 10          | MultiPolygon |      97.53 μs |     1.937 μs |     4.931 μs |  1.18 |    0.10 |    4.8828 |         - |         - |    20.16 KB |        0.53 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 | 10          | MultiPolygon |      83.18 μs |     1.651 μs |     4.603 μs |  1.00 |    0.00 |    9.2773 |    0.1221 |         - |    38.05 KB |        1.00 |
-|                         |               |             |              |               |              |              |       |         |           |           |           |             |             |
-| JsonReaderBenchmark     | .NET 6.0      | 100         | All          |     526.45 μs |    10.437 μs |    24.190 μs |  1.46 |    0.11 |   20.5078 |    0.9766 |         - |    83.88 KB |        0.52 |
-| SystemTextJsonBenchmark | .NET 6.0      | 100         | All          |     388.72 μs |     7.755 μs |    16.527 μs |  1.07 |    0.08 |   39.0625 |    3.4180 |         - |   161.09 KB |        1.00 |
-| JsonReaderBenchmark     | .NET 7.0      | 100         | All          |     525.17 μs |    10.467 μs |    19.915 μs |  1.45 |    0.12 |   20.5078 |    0.9766 |         - |    83.88 KB |        0.52 |
-| SystemTextJsonBenchmark | .NET 7.0      | 100         | All          |     364.38 μs |     7.255 μs |    13.083 μs |  1.00 |    0.07 |   39.0625 |    9.7656 |         - |   161.13 KB |        1.00 |
-| JsonReaderBenchmark     | NativeAOT 7.0 | 100         | All          |     504.33 μs |    10.086 μs |    27.267 μs |  1.39 |    0.11 |   20.5078 |    0.9766 |         - |    83.88 KB |        0.52 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 | 100         | All          |     364.79 μs |     7.257 μs |    20.350 μs |  1.00 |    0.00 |   39.0625 |    9.7656 |         - |   161.13 KB |        1.00 |
-|                         |               |             |              |               |              |              |       |         |           |           |           |             |             |
-| JsonReaderBenchmark     | .NET 6.0      | 100         | MultiPolygon |   1,019.00 μs |    20.298 μs |    46.637 μs |  1.25 |    0.07 |   46.8750 |   15.6250 |         - |   199.17 KB |        0.53 |
-| SystemTextJsonBenchmark | .NET 6.0      | 100         | MultiPolygon |     922.65 μs |    18.362 μs |    48.694 μs |  1.14 |    0.06 |   83.0078 |   25.3906 |         - |   373.45 KB |        1.00 |
-| JsonReaderBenchmark     | .NET 7.0      | 100         | MultiPolygon |     990.79 μs |    19.510 μs |    46.369 μs |  1.23 |    0.07 |   47.8516 |   15.6250 |         - |   199.16 KB |        0.53 |
-| SystemTextJsonBenchmark | .NET 7.0      | 100         | MultiPolygon |     845.85 μs |    16.686 μs |    33.324 μs |  1.04 |    0.05 |   82.0313 |   37.1094 |         - |   373.48 KB |        1.00 |
-| JsonReaderBenchmark     | NativeAOT 7.0 | 100         | MultiPolygon |     994.97 μs |    19.737 μs |    35.083 μs |  1.23 |    0.05 |   47.8516 |   15.6250 |         - |   199.16 KB |        0.53 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 | 100         | MultiPolygon |     809.81 μs |    15.948 μs |    22.356 μs |  1.00 |    0.00 |   83.0078 |   33.2031 |         - |   373.48 KB |        1.00 |
-|                         |               |             |              |               |              |              |       |         |           |           |           |             |             |
-| JsonReaderBenchmark     | .NET 6.0      | 1000        | All          |   5,093.26 μs |    80.493 μs |    71.355 μs |  1.38 |    0.03 |  132.8125 |   62.5000 |         - |   844.31 KB |        0.52 |
-| SystemTextJsonBenchmark | .NET 6.0      | 1000        | All          |   4,069.82 μs |    80.943 μs |    79.497 μs |  1.11 |    0.02 |  257.8125 |  125.0000 |         - |  1609.24 KB |        1.00 |
-| JsonReaderBenchmark     | .NET 7.0      | 1000        | All          |   4,941.00 μs |    81.365 μs |    76.109 μs |  1.34 |    0.03 |  132.8125 |  125.0000 |         - |   844.31 KB |        0.52 |
-| SystemTextJsonBenchmark | .NET 7.0      | 1000        | All          |   3,668.58 μs |    55.642 μs |    49.325 μs |  1.00 |    0.02 |  261.7188 |  257.8125 |         - |  1609.27 KB |        1.00 |
-| JsonReaderBenchmark     | NativeAOT 7.0 | 1000        | All          |   4,899.00 μs |    89.187 μs |    83.426 μs |  1.33 |    0.03 |  132.8125 |  125.0000 |         - |   844.31 KB |        0.52 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 | 1000        | All          |   3,677.57 μs |    60.946 μs |    57.009 μs |  1.00 |    0.00 |  261.7188 |  257.8125 |         - |  1609.27 KB |        1.00 |
-|                         |               |             |              |               |              |              |       |         |           |           |           |             |             |
-| JsonReaderBenchmark     | .NET 6.0      | 1000        | MultiPolygon |  10,301.49 μs |   147.689 μs |   130.922 μs |  1.07 |    0.02 |  312.5000 |  156.2500 |         - |  1985.12 KB |        0.53 |
-| SystemTextJsonBenchmark | .NET 6.0      | 1000        | MultiPolygon |  10,380.42 μs |   207.354 μs |   221.867 μs |  1.07 |    0.04 |  593.7500 |  296.8750 |         - |  3713.12 KB |        1.00 |
-| JsonReaderBenchmark     | .NET 7.0      | 1000        | MultiPolygon |   9,756.26 μs |   189.087 μs |   185.708 μs |  1.01 |    0.03 |  312.5000 |  296.8750 |         - |  1985.12 KB |        0.53 |
-| SystemTextJsonBenchmark | .NET 7.0      | 1000        | MultiPolygon |   9,409.72 μs |   181.121 μs |   169.421 μs |  0.98 |    0.03 |  593.7500 |  578.1250 |         - |  3713.15 KB |        1.00 |
-| JsonReaderBenchmark     | NativeAOT 7.0 | 1000        | MultiPolygon |   9,895.79 μs |   178.855 μs |   158.550 μs |  1.03 |    0.02 |  312.5000 |  296.8750 |         - |  1985.12 KB |        0.53 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 | 1000        | MultiPolygon |   9,680.68 μs |   189.996 μs |   218.800 μs |  1.00 |    0.00 |  593.7500 |  578.1250 |         - |  3713.15 KB |        1.00 |
-|                         |               |             |              |               |              |              |       |         |           |           |           |             |             |
-| JsonReaderBenchmark     | .NET 6.0      | 10000       | All          |  63,113.40 μs | 1,140.368 μs | 1,066.701 μs |  0.95 |    0.04 | 1375.0000 |  500.0000 |  125.0000 |  8536.96 KB |        0.52 |
-| SystemTextJsonBenchmark | .NET 6.0      | 10000       | All          |  60,578.91 μs | 1,211.539 μs | 1,850.148 μs |  0.92 |    0.04 | 2750.0000 | 1250.0000 |  375.0000 | 16469.52 KB |        1.00 |
-| JsonReaderBenchmark     | .NET 7.0      | 10000       | All          |  60,089.65 μs | 1,164.006 μs | 1,777.559 μs |  0.91 |    0.04 | 1444.4444 |  555.5556 |  111.1111 |  8537.14 KB |        0.52 |
-| SystemTextJsonBenchmark | .NET 7.0      | 10000       | All          |  65,042.87 μs | 1,295.430 μs | 2,091.877 μs |  0.99 |    0.05 | 3000.0000 | 1777.7778 |  555.5556 | 16470.91 KB |        1.00 |
-| JsonReaderBenchmark     | NativeAOT 7.0 | 10000       | All          |  60,257.12 μs | 1,120.240 μs | 1,047.873 μs |  0.91 |    0.03 | 1444.4444 |  555.5556 |  111.1111 |  8536.96 KB |        0.52 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 | 10000       | All          |  65,941.92 μs | 1,301.190 μs | 2,244.488 μs |  1.00 |    0.00 | 3000.0000 | 1777.7778 |  555.5556 | 16470.68 KB |        1.00 |
-|                         |               |             |              |               |              |              |       |         |           |           |           |             |             |
-| JsonReaderBenchmark     | .NET 6.0      | 10000       | MultiPolygon | 130,158.13 μs | 2,516.953 μs | 3,918.593 μs |  1.02 |    0.04 | 3500.0000 | 1500.0000 |  500.0000 | 19945.64 KB |        0.53 |
-| SystemTextJsonBenchmark | .NET 6.0      | 10000       | MultiPolygon | 146,698.48 μs | 2,909.600 μs | 6,073.419 μs |  1.16 |    0.06 | 6750.0000 | 3000.0000 | 1000.0000 | 37510.12 KB |        1.00 |
-| JsonReaderBenchmark     | .NET 7.0      | 10000       | MultiPolygon | 119,218.10 μs | 2,369.504 μs | 3,243.404 μs |  0.94 |    0.03 | 3250.0000 | 1250.0000 |  250.0000 | 19945.11 KB |        0.53 |
-| SystemTextJsonBenchmark | .NET 7.0      | 10000       | MultiPolygon | 127,485.37 μs | 2,488.375 μs | 4,292.325 μs |  1.00 |    0.04 | 6500.0000 | 3000.0000 |  750.0000 |  37511.3 KB |        1.00 |
-| JsonReaderBenchmark     | NativeAOT 7.0 | 10000       | MultiPolygon | 123,240.28 μs | 2,443.043 μs | 2,508.826 μs |  0.97 |    0.04 | 3600.0000 | 1400.0000 |  400.0000 | 19945.28 KB |        0.53 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 | 10000       | MultiPolygon | 127,045.45 μs | 2,512.918 μs | 3,761.218 μs |  1.00 |    0.00 | 6500.0000 | 3000.0000 |  750.0000 | 37510.46 KB |        1.00 |
+
+|                  Method |       Runtime | ObjectCount |    SampleSet |          Mean |         Error |        StdDev |        Median | Ratio | RatioSD |      Gen0 |      Gen1 |      Gen2 |   Allocated | Alloc Ratio |
+|------------------------ |-------------- |------------ |------------- |--------------:|--------------:|--------------:|--------------:|------:|--------:|----------:|----------:|----------:|------------:|------------:|
+|     JsonReaderBenchmark |      .NET 6.0 |          10 |          All |     107.64 us |      4.443 us |     12.604 us |     106.22 us |  1.80 |    0.30 |    2.4414 |         - |         - |    10.02 KB |        0.61 |
+| SystemTextJsonBenchmark |      .NET 6.0 |          10 |          All |      64.51 us |      3.668 us |     10.525 us |      64.49 us |  1.09 |    0.25 |    4.0283 |         - |         - |    16.52 KB |        1.00 |
+|     JsonReaderBenchmark |      .NET 7.0 |          10 |          All |     115.35 us |      7.387 us |     21.666 us |     109.83 us |  1.96 |    0.51 |    2.4414 |         - |         - |    10.02 KB |        0.61 |
+| SystemTextJsonBenchmark |      .NET 7.0 |          10 |          All |      89.88 us |      5.434 us |     16.023 us |      90.87 us |  1.51 |    0.33 |    4.0283 |         - |         - |    16.55 KB |        1.00 |
+|     JsonReaderBenchmark | NativeAOT 7.0 |          10 |          All |     126.09 us |      7.309 us |     21.437 us |     126.91 us |  2.12 |    0.42 |    2.4414 |         - |         - |    10.02 KB |        0.61 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 |          10 |          All |      60.37 us |      2.882 us |      8.452 us |      58.99 us |  1.00 |    0.00 |    4.0283 |         - |         - |    16.55 KB |        1.00 |
+|                         |               |             |              |               |               |               |               |       |         |           |           |           |             |             |
+|     JsonReaderBenchmark |      .NET 6.0 |          10 | MultiPolygon |     277.33 us |     16.455 us |     47.475 us |     267.42 us |  1.69 |    0.38 |    6.3477 |         - |         - |    26.72 KB |        0.65 |
+| SystemTextJsonBenchmark |      .NET 6.0 |          10 | MultiPolygon |     185.33 us |     18.201 us |     53.094 us |     173.14 us |  1.13 |    0.38 |    9.7656 |         - |         - |    41.39 KB |        1.00 |
+|     JsonReaderBenchmark |      .NET 7.0 |          10 | MultiPolygon |     229.31 us |     16.622 us |     47.958 us |     221.21 us |  1.40 |    0.36 |    6.3477 |         - |         - |    26.72 KB |        0.65 |
+| SystemTextJsonBenchmark |      .NET 7.0 |          10 | MultiPolygon |     164.54 us |     10.203 us |     29.764 us |     161.83 us |  1.00 |    0.23 |   10.0098 |         - |         - |    41.42 KB |        1.00 |
+|     JsonReaderBenchmark | NativeAOT 7.0 |          10 | MultiPolygon |     273.79 us |     26.971 us |     78.675 us |     252.71 us |  1.67 |    0.52 |    6.3477 |         - |         - |    26.72 KB |        0.65 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 |          10 | MultiPolygon |     168.58 us |      9.231 us |     26.487 us |     164.39 us |  1.00 |    0.00 |   10.0098 |         - |         - |    41.42 KB |        1.00 |
+|                         |               |             |              |               |               |               |               |       |         |           |           |           |             |             |
+|     JsonReaderBenchmark |      .NET 6.0 |         100 |          All |   1,155.46 us |     63.990 us |    186.662 us |   1,143.43 us |  1.71 |    0.42 |   25.3906 |         - |         - |   107.19 KB |        0.63 |
+| SystemTextJsonBenchmark |      .NET 6.0 |         100 |          All |     733.39 us |     51.815 us |    144.440 us |     701.48 us |  1.10 |    0.29 |   41.0156 |    3.9063 |         - |   170.35 KB |        1.00 |
+|     JsonReaderBenchmark |      .NET 7.0 |         100 |          All |   1,266.09 us |    103.432 us |    303.347 us |   1,215.61 us |  1.90 |    0.61 |   25.3906 |    3.9063 |         - |   107.19 KB |        0.63 |
+| SystemTextJsonBenchmark |      .NET 7.0 |         100 |          All |     646.42 us |     34.145 us |     96.308 us |     621.46 us |  0.96 |    0.21 |   41.0156 |    2.9297 |         - |   170.38 KB |        1.00 |
+|     JsonReaderBenchmark | NativeAOT 7.0 |         100 |          All |   1,416.92 us |    117.686 us |    346.999 us |   1,317.38 us |  2.12 |    0.63 |   25.3906 |    3.9063 |         - |   107.19 KB |        0.63 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 |         100 |          All |     697.47 us |     41.941 us |    119.659 us |     676.30 us |  1.00 |    0.00 |   41.0156 |    2.9297 |         - |   170.38 KB |        1.00 |
+|                         |               |             |              |               |               |               |               |       |         |           |           |           |             |             |
+|     JsonReaderBenchmark |      .NET 6.0 |         100 | MultiPolygon |   2,296.71 us |    118.628 us |    344.162 us |   2,209.99 us |  1.13 |    0.29 |   62.5000 |   19.5313 |         - |   264.79 KB |        0.65 |
+| SystemTextJsonBenchmark |      .NET 6.0 |         100 | MultiPolygon |   1,749.16 us |    107.134 us |    305.659 us |   1,664.00 us |  0.88 |    0.26 |   82.0313 |   27.3438 |         - |   407.76 KB |        1.00 |
+|     JsonReaderBenchmark |      .NET 7.0 |         100 | MultiPolygon |   2,339.49 us |    121.793 us |    353.343 us |   2,277.38 us |  1.16 |    0.30 |   62.5000 |   19.5313 |         - |   264.79 KB |        0.65 |
+| SystemTextJsonBenchmark |      .NET 7.0 |         100 | MultiPolygon |   1,588.36 us |     70.990 us |    202.538 us |   1,579.53 us |  0.80 |    0.21 |   85.9375 |   35.1563 |         - |   407.79 KB |        1.00 |
+|     JsonReaderBenchmark | NativeAOT 7.0 |         100 | MultiPolygon |   2,559.98 us |    180.068 us |    525.266 us |   2,515.30 us |  1.27 |    0.42 |   64.4531 |   21.4844 |         - |   264.79 KB |        0.65 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 |         100 | MultiPolygon |   2,154.43 us |    174.058 us |    513.215 us |   2,077.98 us |  1.00 |    0.00 |   87.8906 |   33.2031 |         - |   407.79 KB |        1.00 |
+|                         |               |             |              |               |               |               |               |       |         |           |           |           |             |             |
+|     JsonReaderBenchmark |      .NET 6.0 |        1000 |          All |  13,797.56 us |  1,010.837 us |  2,948.659 us |  13,126.70 us |  1.82 |    0.40 |  156.2500 |   62.5000 |         - |     1081 KB |        0.63 |
+| SystemTextJsonBenchmark |      .NET 6.0 |        1000 |          All |   8,510.29 us |    476.227 us |  1,358.704 us |   8,289.47 us |  1.12 |    0.23 |  265.6250 |  125.0000 |         - |   1704.2 KB |        1.00 |
+|     JsonReaderBenchmark |      .NET 7.0 |        1000 |          All |  11,832.44 us |    764.299 us |  2,217.369 us |  11,243.20 us |  1.57 |    0.37 |  171.8750 |  156.2500 |         - |     1081 KB |        0.63 |
+| SystemTextJsonBenchmark |      .NET 7.0 |        1000 |          All |   7,787.50 us |    372.270 us |  1,080.023 us |   7,676.07 us |  1.03 |    0.19 |  265.6250 |  250.0000 |         - |  1704.21 KB |        1.00 |
+|     JsonReaderBenchmark | NativeAOT 7.0 |        1000 |          All |  12,580.42 us |    840.195 us |  2,437.559 us |  12,080.19 us |  1.68 |    0.48 |  171.8750 |  156.2500 |         - |     1081 KB |        0.63 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 |        1000 |          All |   7,734.19 us |    484.599 us |  1,413.597 us |   7,465.44 us |  1.00 |    0.00 |  265.6250 |  250.0000 |         - |  1704.23 KB |        1.00 |
+|                         |               |             |              |               |               |               |               |       |         |           |           |           |             |             |
+|     JsonReaderBenchmark |      .NET 6.0 |        1000 | MultiPolygon |  28,557.35 us |  1,731.647 us |  5,051.297 us |  27,777.35 us |  1.51 |    0.37 |  406.2500 |  187.5000 |         - |  2641.37 KB |        0.65 |
+| SystemTextJsonBenchmark |      .NET 6.0 |        1000 | MultiPolygon |  21,377.49 us |  1,370.007 us |  3,841.647 us |  20,630.76 us |  1.13 |    0.24 |  656.2500 |  312.5000 |         - |  4056.82 KB |        1.00 |
+|     JsonReaderBenchmark |      .NET 7.0 |        1000 | MultiPolygon |  26,085.62 us |  1,267.862 us |  3,637.734 us |  25,941.45 us |  1.38 |    0.28 |  406.2500 |  375.0000 |         - |  2641.37 KB |        0.65 |
+| SystemTextJsonBenchmark |      .NET 7.0 |        1000 | MultiPolygon |  20,511.24 us |  1,108.834 us |  3,199.238 us |  20,036.13 us |  1.08 |    0.22 |  656.2500 |  625.0000 |         - |  4056.86 KB |        1.00 |
+|     JsonReaderBenchmark | NativeAOT 7.0 |        1000 | MultiPolygon |  28,741.63 us |  2,139.559 us |  6,274.956 us |  27,943.37 us |  1.52 |    0.40 |  375.0000 |  312.5000 |         - |  2641.38 KB |        0.65 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 |        1000 | MultiPolygon |  19,308.50 us |    973.496 us |  2,824.287 us |  18,594.40 us |  1.00 |    0.00 |  656.2500 |  625.0000 |         - |  4056.85 KB |        1.00 |
+|                         |               |             |              |               |               |               |               |       |         |           |           |           |             |             |
+|     JsonReaderBenchmark |      .NET 6.0 |       10000 |          All | 140,908.96 us |  6,766.913 us | 19,739.404 us | 136,317.40 us |  1.33 |    0.24 | 2000.0000 |  750.0000 |  250.0000 | 10904.08 KB |        0.63 |
+| SystemTextJsonBenchmark |      .NET 6.0 |       10000 |          All | 131,826.77 us |  8,006.933 us | 23,608.621 us | 127,007.23 us |  1.24 |    0.30 | 3000.0000 | 1500.0000 |  500.0000 | 17418.09 KB |        1.00 |
+|     JsonReaderBenchmark |      .NET 7.0 |       10000 |          All | 157,915.71 us | 14,169.957 us | 41,780.437 us | 146,523.96 us |  1.50 |    0.47 | 2000.0000 |  750.0000 |  250.0000 |  10902.9 KB |        0.63 |
+| SystemTextJsonBenchmark |      .NET 7.0 |       10000 |          All | 116,689.56 us |  6,214.653 us | 18,029.835 us | 118,253.00 us |  1.10 |    0.21 | 3200.0000 | 1800.0000 |  600.0000 | 17419.33 KB |        1.00 |
+|     JsonReaderBenchmark | NativeAOT 7.0 |       10000 |          All | 154,409.44 us | 12,657.378 us | 37,320.565 us | 145,850.53 us |  1.45 |    0.39 | 1666.6667 |  666.6667 |         - | 10902.25 KB |        0.63 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 |       10000 |          All | 107,816.94 us |  5,196.811 us | 15,159.340 us | 105,062.48 us |  1.00 |    0.00 | 3000.0000 | 1750.0000 |  500.0000 | 17418.92 KB |        1.00 |
+|                         |               |             |              |               |               |               |               |       |         |           |           |           |             |             |
+|     JsonReaderBenchmark |      .NET 6.0 |       10000 | MultiPolygon | 293,468.74 us | 14,792.433 us | 41,963.671 us | 292,364.05 us |  1.36 |    0.26 | 4000.0000 | 1000.0000 |         - | 26506.64 KB |        0.65 |
+| SystemTextJsonBenchmark |      .NET 6.0 |       10000 | MultiPolygon | 259,996.72 us | 17,096.448 us | 49,599.895 us | 253,629.60 us |  1.20 |    0.26 | 6500.0000 | 2500.0000 |  500.0000 | 40948.99 KB |        1.00 |
+|     JsonReaderBenchmark |      .NET 7.0 |       10000 | MultiPolygon | 269,429.68 us | 13,348.577 us | 39,149.066 us | 260,418.40 us |  1.24 |    0.21 | 4000.0000 | 1500.0000 |         - | 26506.64 KB |        0.65 |
+| SystemTextJsonBenchmark |      .NET 7.0 |       10000 | MultiPolygon | 240,378.36 us | 10,937.142 us | 31,730.633 us | 236,796.45 us |  1.11 |    0.20 | 7500.0000 | 3500.0000 | 1000.0000 | 40951.48 KB |        1.00 |
+|     JsonReaderBenchmark | NativeAOT 7.0 |       10000 | MultiPolygon | 281,075.48 us | 17,166.275 us | 50,345.712 us | 270,001.27 us |  1.30 |    0.28 | 4333.3333 | 1666.6667 |  333.3333 | 26508.55 KB |        0.65 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 |       10000 | MultiPolygon | 219,534.95 us |  9,294.446 us | 26,667.507 us | 216,748.60 us |  1.00 |    0.00 | 7000.0000 | 3333.3333 |  666.6667 | 40949.07 KB |        1.00 |
+
 
 When benchmarking deserialization a subset of an example payload from the
 [GitHub REST API (Merge a branch)], we measure the following:

--- a/bench/README.md
+++ b/bench/README.md
@@ -16,114 +16,112 @@ In another configuration, we benchmark the worst-case scenario performance of
 `JsonReader.Either` by deserializing an array with elements of type
 `MultiPolygon`. We measure the following:
 
-    BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.963)
+    BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.819)
     Intel Core i7-1065G7 CPU 1.30GHz, 1 CPU, 8 logical and 4 physical cores
-    .NET SDK=7.0.101
-      [Host]     : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT AVX2
-      Job-YZVNIW : .NET 6.0.12 (6.0.1222.56807), X64 RyuJIT AVX2
-      Job-MRCBRH : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT AVX2
-      Job-DTLXOA : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT AVX2
+    .NET SDK=7.0.100
+      [Host]     : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
+      Job-IBGVMK : .NET 6.0.11 (6.0.1122.52304), X64 RyuJIT AVX2
+      Job-TTWDSU : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
+      Job-XACLOO : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
 
-
-|                  Method |       Runtime | ObjectCount |    SampleSet |          Mean |         Error |        StdDev |        Median | Ratio | RatioSD |      Gen0 |      Gen1 |      Gen2 |   Allocated | Alloc Ratio |
-|------------------------ |-------------- |------------ |------------- |--------------:|--------------:|--------------:|--------------:|------:|--------:|----------:|----------:|----------:|------------:|------------:|
-|     JsonReaderBenchmark |      .NET 6.0 |          10 |          All |     107.64 us |      4.443 us |     12.604 us |     106.22 us |  1.80 |    0.30 |    2.4414 |         - |         - |    10.02 KB |        0.61 |
-| SystemTextJsonBenchmark |      .NET 6.0 |          10 |          All |      64.51 us |      3.668 us |     10.525 us |      64.49 us |  1.09 |    0.25 |    4.0283 |         - |         - |    16.52 KB |        1.00 |
-|     JsonReaderBenchmark |      .NET 7.0 |          10 |          All |     115.35 us |      7.387 us |     21.666 us |     109.83 us |  1.96 |    0.51 |    2.4414 |         - |         - |    10.02 KB |        0.61 |
-| SystemTextJsonBenchmark |      .NET 7.0 |          10 |          All |      89.88 us |      5.434 us |     16.023 us |      90.87 us |  1.51 |    0.33 |    4.0283 |         - |         - |    16.55 KB |        1.00 |
-|     JsonReaderBenchmark | NativeAOT 7.0 |          10 |          All |     126.09 us |      7.309 us |     21.437 us |     126.91 us |  2.12 |    0.42 |    2.4414 |         - |         - |    10.02 KB |        0.61 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 |          10 |          All |      60.37 us |      2.882 us |      8.452 us |      58.99 us |  1.00 |    0.00 |    4.0283 |         - |         - |    16.55 KB |        1.00 |
-|                         |               |             |              |               |               |               |               |       |         |           |           |           |             |             |
-|     JsonReaderBenchmark |      .NET 6.0 |          10 | MultiPolygon |     277.33 us |     16.455 us |     47.475 us |     267.42 us |  1.69 |    0.38 |    6.3477 |         - |         - |    26.72 KB |        0.65 |
-| SystemTextJsonBenchmark |      .NET 6.0 |          10 | MultiPolygon |     185.33 us |     18.201 us |     53.094 us |     173.14 us |  1.13 |    0.38 |    9.7656 |         - |         - |    41.39 KB |        1.00 |
-|     JsonReaderBenchmark |      .NET 7.0 |          10 | MultiPolygon |     229.31 us |     16.622 us |     47.958 us |     221.21 us |  1.40 |    0.36 |    6.3477 |         - |         - |    26.72 KB |        0.65 |
-| SystemTextJsonBenchmark |      .NET 7.0 |          10 | MultiPolygon |     164.54 us |     10.203 us |     29.764 us |     161.83 us |  1.00 |    0.23 |   10.0098 |         - |         - |    41.42 KB |        1.00 |
-|     JsonReaderBenchmark | NativeAOT 7.0 |          10 | MultiPolygon |     273.79 us |     26.971 us |     78.675 us |     252.71 us |  1.67 |    0.52 |    6.3477 |         - |         - |    26.72 KB |        0.65 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 |          10 | MultiPolygon |     168.58 us |      9.231 us |     26.487 us |     164.39 us |  1.00 |    0.00 |   10.0098 |         - |         - |    41.42 KB |        1.00 |
-|                         |               |             |              |               |               |               |               |       |         |           |           |           |             |             |
-|     JsonReaderBenchmark |      .NET 6.0 |         100 |          All |   1,155.46 us |     63.990 us |    186.662 us |   1,143.43 us |  1.71 |    0.42 |   25.3906 |         - |         - |   107.19 KB |        0.63 |
-| SystemTextJsonBenchmark |      .NET 6.0 |         100 |          All |     733.39 us |     51.815 us |    144.440 us |     701.48 us |  1.10 |    0.29 |   41.0156 |    3.9063 |         - |   170.35 KB |        1.00 |
-|     JsonReaderBenchmark |      .NET 7.0 |         100 |          All |   1,266.09 us |    103.432 us |    303.347 us |   1,215.61 us |  1.90 |    0.61 |   25.3906 |    3.9063 |         - |   107.19 KB |        0.63 |
-| SystemTextJsonBenchmark |      .NET 7.0 |         100 |          All |     646.42 us |     34.145 us |     96.308 us |     621.46 us |  0.96 |    0.21 |   41.0156 |    2.9297 |         - |   170.38 KB |        1.00 |
-|     JsonReaderBenchmark | NativeAOT 7.0 |         100 |          All |   1,416.92 us |    117.686 us |    346.999 us |   1,317.38 us |  2.12 |    0.63 |   25.3906 |    3.9063 |         - |   107.19 KB |        0.63 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 |         100 |          All |     697.47 us |     41.941 us |    119.659 us |     676.30 us |  1.00 |    0.00 |   41.0156 |    2.9297 |         - |   170.38 KB |        1.00 |
-|                         |               |             |              |               |               |               |               |       |         |           |           |           |             |             |
-|     JsonReaderBenchmark |      .NET 6.0 |         100 | MultiPolygon |   2,296.71 us |    118.628 us |    344.162 us |   2,209.99 us |  1.13 |    0.29 |   62.5000 |   19.5313 |         - |   264.79 KB |        0.65 |
-| SystemTextJsonBenchmark |      .NET 6.0 |         100 | MultiPolygon |   1,749.16 us |    107.134 us |    305.659 us |   1,664.00 us |  0.88 |    0.26 |   82.0313 |   27.3438 |         - |   407.76 KB |        1.00 |
-|     JsonReaderBenchmark |      .NET 7.0 |         100 | MultiPolygon |   2,339.49 us |    121.793 us |    353.343 us |   2,277.38 us |  1.16 |    0.30 |   62.5000 |   19.5313 |         - |   264.79 KB |        0.65 |
-| SystemTextJsonBenchmark |      .NET 7.0 |         100 | MultiPolygon |   1,588.36 us |     70.990 us |    202.538 us |   1,579.53 us |  0.80 |    0.21 |   85.9375 |   35.1563 |         - |   407.79 KB |        1.00 |
-|     JsonReaderBenchmark | NativeAOT 7.0 |         100 | MultiPolygon |   2,559.98 us |    180.068 us |    525.266 us |   2,515.30 us |  1.27 |    0.42 |   64.4531 |   21.4844 |         - |   264.79 KB |        0.65 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 |         100 | MultiPolygon |   2,154.43 us |    174.058 us |    513.215 us |   2,077.98 us |  1.00 |    0.00 |   87.8906 |   33.2031 |         - |   407.79 KB |        1.00 |
-|                         |               |             |              |               |               |               |               |       |         |           |           |           |             |             |
-|     JsonReaderBenchmark |      .NET 6.0 |        1000 |          All |  13,797.56 us |  1,010.837 us |  2,948.659 us |  13,126.70 us |  1.82 |    0.40 |  156.2500 |   62.5000 |         - |     1081 KB |        0.63 |
-| SystemTextJsonBenchmark |      .NET 6.0 |        1000 |          All |   8,510.29 us |    476.227 us |  1,358.704 us |   8,289.47 us |  1.12 |    0.23 |  265.6250 |  125.0000 |         - |   1704.2 KB |        1.00 |
-|     JsonReaderBenchmark |      .NET 7.0 |        1000 |          All |  11,832.44 us |    764.299 us |  2,217.369 us |  11,243.20 us |  1.57 |    0.37 |  171.8750 |  156.2500 |         - |     1081 KB |        0.63 |
-| SystemTextJsonBenchmark |      .NET 7.0 |        1000 |          All |   7,787.50 us |    372.270 us |  1,080.023 us |   7,676.07 us |  1.03 |    0.19 |  265.6250 |  250.0000 |         - |  1704.21 KB |        1.00 |
-|     JsonReaderBenchmark | NativeAOT 7.0 |        1000 |          All |  12,580.42 us |    840.195 us |  2,437.559 us |  12,080.19 us |  1.68 |    0.48 |  171.8750 |  156.2500 |         - |     1081 KB |        0.63 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 |        1000 |          All |   7,734.19 us |    484.599 us |  1,413.597 us |   7,465.44 us |  1.00 |    0.00 |  265.6250 |  250.0000 |         - |  1704.23 KB |        1.00 |
-|                         |               |             |              |               |               |               |               |       |         |           |           |           |             |             |
-|     JsonReaderBenchmark |      .NET 6.0 |        1000 | MultiPolygon |  28,557.35 us |  1,731.647 us |  5,051.297 us |  27,777.35 us |  1.51 |    0.37 |  406.2500 |  187.5000 |         - |  2641.37 KB |        0.65 |
-| SystemTextJsonBenchmark |      .NET 6.0 |        1000 | MultiPolygon |  21,377.49 us |  1,370.007 us |  3,841.647 us |  20,630.76 us |  1.13 |    0.24 |  656.2500 |  312.5000 |         - |  4056.82 KB |        1.00 |
-|     JsonReaderBenchmark |      .NET 7.0 |        1000 | MultiPolygon |  26,085.62 us |  1,267.862 us |  3,637.734 us |  25,941.45 us |  1.38 |    0.28 |  406.2500 |  375.0000 |         - |  2641.37 KB |        0.65 |
-| SystemTextJsonBenchmark |      .NET 7.0 |        1000 | MultiPolygon |  20,511.24 us |  1,108.834 us |  3,199.238 us |  20,036.13 us |  1.08 |    0.22 |  656.2500 |  625.0000 |         - |  4056.86 KB |        1.00 |
-|     JsonReaderBenchmark | NativeAOT 7.0 |        1000 | MultiPolygon |  28,741.63 us |  2,139.559 us |  6,274.956 us |  27,943.37 us |  1.52 |    0.40 |  375.0000 |  312.5000 |         - |  2641.38 KB |        0.65 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 |        1000 | MultiPolygon |  19,308.50 us |    973.496 us |  2,824.287 us |  18,594.40 us |  1.00 |    0.00 |  656.2500 |  625.0000 |         - |  4056.85 KB |        1.00 |
-|                         |               |             |              |               |               |               |               |       |         |           |           |           |             |             |
-|     JsonReaderBenchmark |      .NET 6.0 |       10000 |          All | 140,908.96 us |  6,766.913 us | 19,739.404 us | 136,317.40 us |  1.33 |    0.24 | 2000.0000 |  750.0000 |  250.0000 | 10904.08 KB |        0.63 |
-| SystemTextJsonBenchmark |      .NET 6.0 |       10000 |          All | 131,826.77 us |  8,006.933 us | 23,608.621 us | 127,007.23 us |  1.24 |    0.30 | 3000.0000 | 1500.0000 |  500.0000 | 17418.09 KB |        1.00 |
-|     JsonReaderBenchmark |      .NET 7.0 |       10000 |          All | 157,915.71 us | 14,169.957 us | 41,780.437 us | 146,523.96 us |  1.50 |    0.47 | 2000.0000 |  750.0000 |  250.0000 |  10902.9 KB |        0.63 |
-| SystemTextJsonBenchmark |      .NET 7.0 |       10000 |          All | 116,689.56 us |  6,214.653 us | 18,029.835 us | 118,253.00 us |  1.10 |    0.21 | 3200.0000 | 1800.0000 |  600.0000 | 17419.33 KB |        1.00 |
-|     JsonReaderBenchmark | NativeAOT 7.0 |       10000 |          All | 154,409.44 us | 12,657.378 us | 37,320.565 us | 145,850.53 us |  1.45 |    0.39 | 1666.6667 |  666.6667 |         - | 10902.25 KB |        0.63 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 |       10000 |          All | 107,816.94 us |  5,196.811 us | 15,159.340 us | 105,062.48 us |  1.00 |    0.00 | 3000.0000 | 1750.0000 |  500.0000 | 17418.92 KB |        1.00 |
-|                         |               |             |              |               |               |               |               |       |         |           |           |           |             |             |
-|     JsonReaderBenchmark |      .NET 6.0 |       10000 | MultiPolygon | 293,468.74 us | 14,792.433 us | 41,963.671 us | 292,364.05 us |  1.36 |    0.26 | 4000.0000 | 1000.0000 |         - | 26506.64 KB |        0.65 |
-| SystemTextJsonBenchmark |      .NET 6.0 |       10000 | MultiPolygon | 259,996.72 us | 17,096.448 us | 49,599.895 us | 253,629.60 us |  1.20 |    0.26 | 6500.0000 | 2500.0000 |  500.0000 | 40948.99 KB |        1.00 |
-|     JsonReaderBenchmark |      .NET 7.0 |       10000 | MultiPolygon | 269,429.68 us | 13,348.577 us | 39,149.066 us | 260,418.40 us |  1.24 |    0.21 | 4000.0000 | 1500.0000 |         - | 26506.64 KB |        0.65 |
-| SystemTextJsonBenchmark |      .NET 7.0 |       10000 | MultiPolygon | 240,378.36 us | 10,937.142 us | 31,730.633 us | 236,796.45 us |  1.11 |    0.20 | 7500.0000 | 3500.0000 | 1000.0000 | 40951.48 KB |        1.00 |
-|     JsonReaderBenchmark | NativeAOT 7.0 |       10000 | MultiPolygon | 281,075.48 us | 17,166.275 us | 50,345.712 us | 270,001.27 us |  1.30 |    0.28 | 4333.3333 | 1666.6667 |  333.3333 | 26508.55 KB |        0.65 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 |       10000 | MultiPolygon | 219,534.95 us |  9,294.446 us | 26,667.507 us | 216,748.60 us |  1.00 |    0.00 | 7000.0000 | 3333.3333 |  666.6667 | 40949.07 KB |        1.00 |
-
+| Method                  | Runtime       | ObjectCount | SampleSet    |          Mean |        Error |       StdDev | Ratio | RatioSD |      Gen0 |      Gen1 |      Gen2 |   Allocated | Alloc Ratio |
+| ----------------------- | ------------- | ----------- | ------------ | ------------: | -----------: | -----------: | ----: | ------: | --------: | --------: | --------: | ----------: | ----------: |
+| JsonReaderBenchmark     | .NET 6.0      | 10          | All          |      46.14 μs |     0.883 μs |     1.179 μs |  1.37 |    0.06 |    1.8921 |         - |         - |     7.83 KB |        0.50 |
+| SystemTextJsonBenchmark | .NET 6.0      | 10          | All          |      36.19 μs |     0.714 μs |     1.153 μs |  1.09 |    0.06 |    3.7842 |         - |         - |     15.7 KB |        1.00 |
+| JsonReaderBenchmark     | .NET 7.0      | 10          | All          |      45.87 μs |     0.907 μs |     2.155 μs |  1.37 |    0.09 |    1.8921 |         - |         - |     7.83 KB |        0.50 |
+| SystemTextJsonBenchmark | .NET 7.0      | 10          | All          |      34.14 μs |     0.676 μs |     1.805 μs |  1.02 |    0.06 |    3.8452 |         - |         - |    15.73 KB |        1.00 |
+| JsonReaderBenchmark     | NativeAOT 7.0 | 10          | All          |      45.52 μs |     0.910 μs |     1.011 μs |  1.36 |    0.05 |    1.8921 |         - |         - |     7.83 KB |        0.50 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 | 10          | All          |      33.32 μs |     0.661 μs |     1.364 μs |  1.00 |    0.00 |    3.8452 |         - |         - |    15.73 KB |        1.00 |
+|                         |               |             |              |               |              |              |       |         |           |           |           |             |             |
+| JsonReaderBenchmark     | .NET 6.0      | 10          | MultiPolygon |      99.51 μs |     1.948 μs |     3.089 μs |  1.19 |    0.08 |    4.8828 |    0.1221 |         - |    20.16 KB |        0.53 |
+| SystemTextJsonBenchmark | .NET 6.0      | 10          | MultiPolygon |      89.99 μs |     1.796 μs |     3.828 μs |  1.08 |    0.07 |    9.2773 |         - |         - |    38.02 KB |        1.00 |
+| JsonReaderBenchmark     | .NET 7.0      | 10          | MultiPolygon |      96.79 μs |     1.778 μs |     2.493 μs |  1.17 |    0.08 |    4.8828 |         - |         - |    20.16 KB |        0.53 |
+| SystemTextJsonBenchmark | .NET 7.0      | 10          | MultiPolygon |      83.68 μs |     1.667 μs |     4.421 μs |  1.01 |    0.07 |    9.2773 |    0.1221 |         - |    38.05 KB |        1.00 |
+| JsonReaderBenchmark     | NativeAOT 7.0 | 10          | MultiPolygon |      97.53 μs |     1.937 μs |     4.931 μs |  1.18 |    0.10 |    4.8828 |         - |         - |    20.16 KB |        0.53 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 | 10          | MultiPolygon |      83.18 μs |     1.651 μs |     4.603 μs |  1.00 |    0.00 |    9.2773 |    0.1221 |         - |    38.05 KB |        1.00 |
+|                         |               |             |              |               |              |              |       |         |           |           |           |             |             |
+| JsonReaderBenchmark     | .NET 6.0      | 100         | All          |     526.45 μs |    10.437 μs |    24.190 μs |  1.46 |    0.11 |   20.5078 |    0.9766 |         - |    83.88 KB |        0.52 |
+| SystemTextJsonBenchmark | .NET 6.0      | 100         | All          |     388.72 μs |     7.755 μs |    16.527 μs |  1.07 |    0.08 |   39.0625 |    3.4180 |         - |   161.09 KB |        1.00 |
+| JsonReaderBenchmark     | .NET 7.0      | 100         | All          |     525.17 μs |    10.467 μs |    19.915 μs |  1.45 |    0.12 |   20.5078 |    0.9766 |         - |    83.88 KB |        0.52 |
+| SystemTextJsonBenchmark | .NET 7.0      | 100         | All          |     364.38 μs |     7.255 μs |    13.083 μs |  1.00 |    0.07 |   39.0625 |    9.7656 |         - |   161.13 KB |        1.00 |
+| JsonReaderBenchmark     | NativeAOT 7.0 | 100         | All          |     504.33 μs |    10.086 μs |    27.267 μs |  1.39 |    0.11 |   20.5078 |    0.9766 |         - |    83.88 KB |        0.52 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 | 100         | All          |     364.79 μs |     7.257 μs |    20.350 μs |  1.00 |    0.00 |   39.0625 |    9.7656 |         - |   161.13 KB |        1.00 |
+|                         |               |             |              |               |              |              |       |         |           |           |           |             |             |
+| JsonReaderBenchmark     | .NET 6.0      | 100         | MultiPolygon |   1,019.00 μs |    20.298 μs |    46.637 μs |  1.25 |    0.07 |   46.8750 |   15.6250 |         - |   199.17 KB |        0.53 |
+| SystemTextJsonBenchmark | .NET 6.0      | 100         | MultiPolygon |     922.65 μs |    18.362 μs |    48.694 μs |  1.14 |    0.06 |   83.0078 |   25.3906 |         - |   373.45 KB |        1.00 |
+| JsonReaderBenchmark     | .NET 7.0      | 100         | MultiPolygon |     990.79 μs |    19.510 μs |    46.369 μs |  1.23 |    0.07 |   47.8516 |   15.6250 |         - |   199.16 KB |        0.53 |
+| SystemTextJsonBenchmark | .NET 7.0      | 100         | MultiPolygon |     845.85 μs |    16.686 μs |    33.324 μs |  1.04 |    0.05 |   82.0313 |   37.1094 |         - |   373.48 KB |        1.00 |
+| JsonReaderBenchmark     | NativeAOT 7.0 | 100         | MultiPolygon |     994.97 μs |    19.737 μs |    35.083 μs |  1.23 |    0.05 |   47.8516 |   15.6250 |         - |   199.16 KB |        0.53 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 | 100         | MultiPolygon |     809.81 μs |    15.948 μs |    22.356 μs |  1.00 |    0.00 |   83.0078 |   33.2031 |         - |   373.48 KB |        1.00 |
+|                         |               |             |              |               |              |              |       |         |           |           |           |             |             |
+| JsonReaderBenchmark     | .NET 6.0      | 1000        | All          |   5,093.26 μs |    80.493 μs |    71.355 μs |  1.38 |    0.03 |  132.8125 |   62.5000 |         - |   844.31 KB |        0.52 |
+| SystemTextJsonBenchmark | .NET 6.0      | 1000        | All          |   4,069.82 μs |    80.943 μs |    79.497 μs |  1.11 |    0.02 |  257.8125 |  125.0000 |         - |  1609.24 KB |        1.00 |
+| JsonReaderBenchmark     | .NET 7.0      | 1000        | All          |   4,941.00 μs |    81.365 μs |    76.109 μs |  1.34 |    0.03 |  132.8125 |  125.0000 |         - |   844.31 KB |        0.52 |
+| SystemTextJsonBenchmark | .NET 7.0      | 1000        | All          |   3,668.58 μs |    55.642 μs |    49.325 μs |  1.00 |    0.02 |  261.7188 |  257.8125 |         - |  1609.27 KB |        1.00 |
+| JsonReaderBenchmark     | NativeAOT 7.0 | 1000        | All          |   4,899.00 μs |    89.187 μs |    83.426 μs |  1.33 |    0.03 |  132.8125 |  125.0000 |         - |   844.31 KB |        0.52 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 | 1000        | All          |   3,677.57 μs |    60.946 μs |    57.009 μs |  1.00 |    0.00 |  261.7188 |  257.8125 |         - |  1609.27 KB |        1.00 |
+|                         |               |             |              |               |              |              |       |         |           |           |           |             |             |
+| JsonReaderBenchmark     | .NET 6.0      | 1000        | MultiPolygon |  10,301.49 μs |   147.689 μs |   130.922 μs |  1.07 |    0.02 |  312.5000 |  156.2500 |         - |  1985.12 KB |        0.53 |
+| SystemTextJsonBenchmark | .NET 6.0      | 1000        | MultiPolygon |  10,380.42 μs |   207.354 μs |   221.867 μs |  1.07 |    0.04 |  593.7500 |  296.8750 |         - |  3713.12 KB |        1.00 |
+| JsonReaderBenchmark     | .NET 7.0      | 1000        | MultiPolygon |   9,756.26 μs |   189.087 μs |   185.708 μs |  1.01 |    0.03 |  312.5000 |  296.8750 |         - |  1985.12 KB |        0.53 |
+| SystemTextJsonBenchmark | .NET 7.0      | 1000        | MultiPolygon |   9,409.72 μs |   181.121 μs |   169.421 μs |  0.98 |    0.03 |  593.7500 |  578.1250 |         - |  3713.15 KB |        1.00 |
+| JsonReaderBenchmark     | NativeAOT 7.0 | 1000        | MultiPolygon |   9,895.79 μs |   178.855 μs |   158.550 μs |  1.03 |    0.02 |  312.5000 |  296.8750 |         - |  1985.12 KB |        0.53 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 | 1000        | MultiPolygon |   9,680.68 μs |   189.996 μs |   218.800 μs |  1.00 |    0.00 |  593.7500 |  578.1250 |         - |  3713.15 KB |        1.00 |
+|                         |               |             |              |               |              |              |       |         |           |           |           |             |             |
+| JsonReaderBenchmark     | .NET 6.0      | 10000       | All          |  63,113.40 μs | 1,140.368 μs | 1,066.701 μs |  0.95 |    0.04 | 1375.0000 |  500.0000 |  125.0000 |  8536.96 KB |        0.52 |
+| SystemTextJsonBenchmark | .NET 6.0      | 10000       | All          |  60,578.91 μs | 1,211.539 μs | 1,850.148 μs |  0.92 |    0.04 | 2750.0000 | 1250.0000 |  375.0000 | 16469.52 KB |        1.00 |
+| JsonReaderBenchmark     | .NET 7.0      | 10000       | All          |  60,089.65 μs | 1,164.006 μs | 1,777.559 μs |  0.91 |    0.04 | 1444.4444 |  555.5556 |  111.1111 |  8537.14 KB |        0.52 |
+| SystemTextJsonBenchmark | .NET 7.0      | 10000       | All          |  65,042.87 μs | 1,295.430 μs | 2,091.877 μs |  0.99 |    0.05 | 3000.0000 | 1777.7778 |  555.5556 | 16470.91 KB |        1.00 |
+| JsonReaderBenchmark     | NativeAOT 7.0 | 10000       | All          |  60,257.12 μs | 1,120.240 μs | 1,047.873 μs |  0.91 |    0.03 | 1444.4444 |  555.5556 |  111.1111 |  8536.96 KB |        0.52 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 | 10000       | All          |  65,941.92 μs | 1,301.190 μs | 2,244.488 μs |  1.00 |    0.00 | 3000.0000 | 1777.7778 |  555.5556 | 16470.68 KB |        1.00 |
+|                         |               |             |              |               |              |              |       |         |           |           |           |             |             |
+| JsonReaderBenchmark     | .NET 6.0      | 10000       | MultiPolygon | 130,158.13 μs | 2,516.953 μs | 3,918.593 μs |  1.02 |    0.04 | 3500.0000 | 1500.0000 |  500.0000 | 19945.64 KB |        0.53 |
+| SystemTextJsonBenchmark | .NET 6.0      | 10000       | MultiPolygon | 146,698.48 μs | 2,909.600 μs | 6,073.419 μs |  1.16 |    0.06 | 6750.0000 | 3000.0000 | 1000.0000 | 37510.12 KB |        1.00 |
+| JsonReaderBenchmark     | .NET 7.0      | 10000       | MultiPolygon | 119,218.10 μs | 2,369.504 μs | 3,243.404 μs |  0.94 |    0.03 | 3250.0000 | 1250.0000 |  250.0000 | 19945.11 KB |        0.53 |
+| SystemTextJsonBenchmark | .NET 7.0      | 10000       | MultiPolygon | 127,485.37 μs | 2,488.375 μs | 4,292.325 μs |  1.00 |    0.04 | 6500.0000 | 3000.0000 |  750.0000 |  37511.3 KB |        1.00 |
+| JsonReaderBenchmark     | NativeAOT 7.0 | 10000       | MultiPolygon | 123,240.28 μs | 2,443.043 μs | 2,508.826 μs |  0.97 |    0.04 | 3600.0000 | 1400.0000 |  400.0000 | 19945.28 KB |        0.53 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 | 10000       | MultiPolygon | 127,045.45 μs | 2,512.918 μs | 3,761.218 μs |  1.00 |    0.00 | 6500.0000 | 3000.0000 |  750.0000 | 37510.46 KB |        1.00 |
 
 When benchmarking deserialization a subset of an example payload from the
 [GitHub REST API (Merge a branch)], we measure the following:
 
-    BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.963)
+    BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.819)
     Intel Core i7-1065G7 CPU 1.30GHz, 1 CPU, 8 logical and 4 physical cores
-    .NET SDK=7.0.101
-      [Host]     : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT AVX2
-      Job-GBHHXP : .NET 6.0.12 (6.0.1222.56807), X64 RyuJIT AVX2
-      Job-JZANEJ : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT AVX2
-      Job-JTAKIM : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT AVX2
+    .NET SDK=7.0.100
+      [Host]     : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
+      Job-OVWNPR : .NET 6.0.11 (6.0.1122.52304), X64 RyuJIT AVX2
+      Job-KJBBGH : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
+      Job-CKYCTW : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
 
 
-|                  Method |       Runtime | ObjectCount |           Mean |        Error |        StdDev |         Median | Ratio | RatioSD |       Gen0 |      Gen1 |      Gen2 |   Allocated | Alloc Ratio |
-|------------------------ |-------------- |------------ |---------------:|-------------:|--------------:|---------------:|------:|--------:|-----------:|----------:|----------:|------------:|------------:|
-|     JsonReaderBenchmark |      .NET 6.0 |          10 |       829.7 us |     32.92 us |      97.06 us |       814.4 us |  1.79 |    0.29 |    20.5078 |    1.9531 |         - |    84.61 KB |        0.86 |
-| SystemTextJsonBenchmark |      .NET 6.0 |          10 |       495.0 us |     19.81 us |      58.11 us |       488.3 us |  1.07 |    0.18 |    23.9258 |    7.8125 |         - |     98.9 KB |        1.01 |
-|     JsonReaderBenchmark |      .NET 7.0 |          10 |       763.3 us |     26.06 us |      75.18 us |       750.6 us |  1.64 |    0.24 |    20.5078 |    1.9531 |         - |    84.61 KB |        0.86 |
-| SystemTextJsonBenchmark |      .NET 7.0 |          10 |       437.4 us |     14.41 us |      42.02 us |       425.0 us |  0.94 |    0.13 |    23.4375 |    7.8125 |         - |    98.07 KB |        1.00 |
-|     JsonReaderBenchmark | NativeAOT 7.0 |          10 |       730.1 us |     20.06 us |      56.92 us |       731.0 us |  1.57 |    0.18 |    20.5078 |    1.9531 |         - |    84.61 KB |        0.86 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 |          10 |       469.7 us |     17.84 us |      50.32 us |       455.1 us |  1.00 |    0.00 |    23.9258 |    7.8125 |         - |    98.07 KB |        1.00 |
-|                         |               |             |                |              |               |                |       |         |            |           |           |             |             |
-|     JsonReaderBenchmark |      .NET 6.0 |         100 |     8,242.5 us |    230.19 us |     664.16 us |     8,186.2 us |  1.75 |    0.18 |   132.8125 |   62.5000 |         - |    843.7 KB |        0.86 |
-| SystemTextJsonBenchmark |      .NET 6.0 |         100 |     5,236.2 us |    204.64 us |     590.42 us |     5,115.8 us |  1.11 |    0.15 |   156.2500 |   78.1250 |         - |   994.96 KB |        1.01 |
-|     JsonReaderBenchmark |      .NET 7.0 |         100 |     7,875.5 us |    260.36 us |     755.36 us |     7,716.2 us |  1.67 |    0.21 |   132.8125 |  125.0000 |         - |    843.7 KB |        0.86 |
-| SystemTextJsonBenchmark |      .NET 7.0 |         100 |     4,802.9 us |    146.16 us |     426.35 us |     4,760.6 us |  1.02 |    0.11 |   156.2500 |  148.4375 |         - |    986.4 KB |        1.00 |
-|     JsonReaderBenchmark | NativeAOT 7.0 |         100 |     7,769.7 us |    254.58 us |     734.51 us |     7,622.5 us |  1.65 |    0.21 |   132.8125 |  125.0000 |         - |    843.7 KB |        0.86 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 |         100 |     4,752.8 us |    126.98 us |     368.39 us |     4,679.4 us |  1.00 |    0.00 |   156.2500 |  148.4375 |         - |    986.4 KB |        1.00 |
-|                         |               |             |                |              |               |                |       |         |            |           |           |             |             |
-|     JsonReaderBenchmark |      .NET 6.0 |        1000 |    91,705.6 us |  2,731.55 us |   7,924.72 us |    90,147.4 us |  1.18 |    0.26 |  1500.0000 |  666.6667 |  166.6667 |  8431.46 KB |        0.86 |
-| SystemTextJsonBenchmark |      .NET 6.0 |        1000 |    66,529.9 us |  2,066.72 us |   6,028.71 us |    65,676.7 us |  0.85 |    0.18 |  1777.7778 |  777.7778 |  222.2222 |  9875.75 KB |        1.01 |
-|     JsonReaderBenchmark |      .NET 7.0 |        1000 |    94,818.1 us |  3,732.08 us |  10,827.44 us |    92,959.7 us |  1.23 |    0.33 |  1400.0000 |  800.0000 |  200.0000 |  8431.39 KB |        0.86 |
-| SystemTextJsonBenchmark |      .NET 7.0 |        1000 |    71,909.2 us |  2,588.82 us |   7,510.64 us |    70,775.3 us |  0.93 |    0.21 |  1857.1429 | 1000.0000 |  285.7143 |  9789.17 KB |        1.00 |
-|     JsonReaderBenchmark | NativeAOT 7.0 |        1000 |    91,905.9 us |  3,260.01 us |   9,509.61 us |    89,695.9 us |  1.18 |    0.29 |  1500.0000 |  833.3333 |  166.6667 |  8430.87 KB |        0.86 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 |        1000 |    82,566.5 us |  6,914.74 us |  20,388.27 us |    72,473.2 us |  1.00 |    0.00 |  1750.0000 | 1000.0000 |  250.0000 |  9789.55 KB |        1.00 |
-|                         |               |             |                |              |               |                |       |         |            |           |           |             |             |
-|     JsonReaderBenchmark |      .NET 6.0 |       10000 | 1,092,464.8 us | 42,949.12 us | 125,284.58 us | 1,067,990.2 us |  1.16 |    0.31 | 13000.0000 | 5000.0000 |         - | 84397.45 KB |        0.87 |
-| SystemTextJsonBenchmark |      .NET 6.0 |       10000 |   634,041.7 us | 30,142.52 us |  87,927.16 us |   629,761.8 us |  0.68 |    0.23 | 15000.0000 | 5000.0000 |         - | 98321.43 KB |        1.01 |
-|     JsonReaderBenchmark |      .NET 7.0 |       10000 |   775,164.9 us | 31,426.50 us |  90,168.53 us |   750,062.1 us |  0.82 |    0.23 | 14000.0000 | 7000.0000 | 1000.0000 | 84397.85 KB |        0.87 |
-| SystemTextJsonBenchmark |      .NET 7.0 |       10000 |   533,456.7 us | 18,085.20 us |  52,468.43 us |   521,280.2 us |  0.57 |    0.16 | 16000.0000 | 8000.0000 | 1000.0000 |  97466.7 KB |        1.00 |
-|     JsonReaderBenchmark | NativeAOT 7.0 |       10000 | 1,066,155.4 us | 48,754.39 us | 142,218.84 us | 1,038,770.2 us |  1.13 |    0.33 | 14000.0000 | 7000.0000 | 1000.0000 |  84399.3 KB |        0.87 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 |       10000 | 1,005,954.9 us | 83,038.53 us | 244,840.98 us | 1,008,079.6 us |  1.00 |    0.00 | 16000.0000 | 8000.0000 | 1000.0000 | 97462.72 KB |        1.00 |
+|                  Method |       Runtime | ObjectCount |         Mean |        Error |       StdDev |       Median | Ratio | RatioSD |       Gen0 |      Gen1 |      Gen2 |   Allocated | Alloc Ratio |
+|------------------------ |-------------- |------------ |-------------:|-------------:|-------------:|-------------:|------:|--------:|-----------:|----------:|----------:|------------:|------------:|
+|     JsonReaderBenchmark |      .NET 6.0 |          10 |     361.1 us |     11.90 us |     33.17 us |     353.0 us |  1.23 |    0.21 |    19.5313 |    5.8594 |         - |    83.67 KB |        0.85 |
+| SystemTextJsonBenchmark |      .NET 6.0 |          10 |     249.3 us |      4.98 us |     13.64 us |     248.7 us |  0.84 |    0.12 |    23.9258 |    7.8125 |         - |     98.9 KB |        1.01 |
+|     JsonReaderBenchmark |      .NET 7.0 |          10 |     327.6 us |     10.28 us |     29.32 us |     318.4 us |  1.12 |    0.19 |    20.0195 |    1.9531 |         - |    83.67 KB |        0.85 |
+| SystemTextJsonBenchmark |      .NET 7.0 |          10 |     285.3 us |     13.16 us |     35.79 us |     273.4 us |  0.96 |    0.18 |    23.9258 |    7.8125 |         - |    98.07 KB |        1.00 |
+|     JsonReaderBenchmark | NativeAOT 7.0 |          10 |     406.9 us |     34.08 us |     94.44 us |     371.2 us |  1.37 |    0.30 |    20.0195 |    1.9531 |         - |    83.67 KB |        0.85 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 |          10 |     298.6 us |     16.48 us |     46.50 us |     285.7 us |  1.00 |    0.00 |    23.9258 |    7.8125 |         - |    98.07 KB |        1.00 |
+|                         |               |             |              |              |              |              |       |         |            |           |           |             |             |
+|     JsonReaderBenchmark |      .NET 6.0 |         100 |   3,867.9 us |    164.67 us |    456.31 us |   3,714.0 us |  1.28 |    0.23 |   132.8125 |   66.4063 |         - |   834.32 KB |        0.85 |
+| SystemTextJsonBenchmark |      .NET 6.0 |         100 |   3,363.0 us |    219.58 us |    615.72 us |   3,143.9 us |  1.12 |    0.27 |   160.1563 |   78.1250 |         - |   994.96 KB |        1.01 |
+|     JsonReaderBenchmark |      .NET 7.0 |         100 |   3,781.9 us |    131.40 us |    374.89 us |   3,689.5 us |  1.25 |    0.22 |   132.8125 |  128.9063 |         - |   834.32 KB |        0.85 |
+| SystemTextJsonBenchmark |      .NET 7.0 |         100 |   3,047.9 us |    154.99 us |    439.68 us |   2,928.2 us |  0.99 |    0.19 |   160.1563 |  156.2500 |         - |   986.39 KB |        1.00 |
+|     JsonReaderBenchmark | NativeAOT 7.0 |         100 |   3,733.0 us |    165.12 us |    465.73 us |   3,628.0 us |  1.25 |    0.24 |   132.8125 |  125.0000 |         - |   834.32 KB |        0.85 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 |         100 |   3,085.3 us |    185.14 us |    503.69 us |   2,935.6 us |  1.00 |    0.00 |   160.1563 |  156.2500 |         - |   986.39 KB |        1.00 |
+|                         |               |             |              |              |              |              |       |         |            |           |           |             |             |
+|     JsonReaderBenchmark |      .NET 6.0 |        1000 |  48,127.1 us |  2,503.79 us |  7,102.84 us |  45,877.2 us |  0.98 |    0.21 |  1400.0000 |  500.0000 |  100.0000 |  8336.78 KB |        0.85 |
+| SystemTextJsonBenchmark |      .NET 6.0 |        1000 |  44,739.9 us |  1,663.72 us |  4,800.22 us |  43,065.2 us |  0.91 |    0.18 |  1727.2727 |  727.2727 |  272.7273 |  9875.11 KB |        1.01 |
+|     JsonReaderBenchmark |      .NET 7.0 |        1000 |  53,535.8 us |  3,335.49 us |  9,676.85 us |  49,938.4 us |  1.09 |    0.25 |  1555.5556 |  888.8889 |  222.2222 |  8336.96 KB |        0.85 |
+| SystemTextJsonBenchmark |      .NET 7.0 |        1000 |  45,374.4 us |  1,225.50 us |  3,516.18 us |  44,875.0 us |  0.92 |    0.16 |  1833.3333 | 1083.3333 |  333.3333 |  9789.81 KB |        1.00 |
+|     JsonReaderBenchmark | NativeAOT 7.0 |        1000 |  53,250.5 us |  2,668.28 us |  7,569.46 us |  50,447.6 us |  1.09 |    0.26 |  1500.0000 |  875.0000 |  250.0000 |  8337.59 KB |        0.85 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 |        1000 |  50,615.8 us |  3,317.44 us |  9,356.91 us |  48,137.7 us |  1.00 |    0.00 |  1818.1818 | 1000.0000 |  272.7273 |  9789.16 KB |        1.00 |
+|                         |               |             |              |              |              |              |       |         |            |           |           |             |             |
+|     JsonReaderBenchmark |      .NET 6.0 |       10000 | 473,801.2 us | 18,509.33 us | 51,902.14 us | 455,522.1 us |  1.24 |    0.19 | 13000.0000 | 5000.0000 |         - | 83459.95 KB |        0.86 |
+| SystemTextJsonBenchmark |      .NET 6.0 |       10000 | 402,131.6 us | 12,635.45 us | 36,049.65 us | 391,502.2 us |  1.05 |    0.12 | 15000.0000 | 5000.0000 |         - | 98321.43 KB |        1.01 |
+|     JsonReaderBenchmark |      .NET 7.0 |       10000 | 435,829.0 us | 13,578.17 us | 39,392.74 us | 421,647.1 us |  1.14 |    0.15 | 14000.0000 | 7000.0000 | 1000.0000 | 83460.31 KB |        0.86 |
+| SystemTextJsonBenchmark |      .NET 7.0 |       10000 | 378,523.2 us | 12,743.50 us | 37,173.38 us | 362,073.7 us |  1.00 |    0.15 | 16000.0000 | 8000.0000 | 1000.0000 |  97462.8 KB |        1.00 |
+|     JsonReaderBenchmark | NativeAOT 7.0 |       10000 | 430,449.1 us | 16,561.16 us | 47,249.91 us | 412,971.2 us |  1.13 |    0.17 | 14000.0000 | 7000.0000 | 1000.0000 | 83462.89 KB |        0.86 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 |       10000 | 384,891.2 us | 14,468.88 us | 41,280.54 us | 367,407.8 us |  1.00 |    0.00 | 16000.0000 | 8000.0000 | 1000.0000 | 97462.79 KB |        1.00 |
 
   [GitHub REST API]: https://docs.github.com/en/rest/branches/branches#merge-a-branch

--- a/bench/README.md
+++ b/bench/README.md
@@ -87,43 +87,43 @@ In another configuration, we benchmark the worst-case scenario performance of
 When benchmarking deserialization a subset of an example payload from the
 [GitHub REST API (Merge a branch)], we measure the following:
 
-    BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.819)
+    BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.963)
     Intel Core i7-1065G7 CPU 1.30GHz, 1 CPU, 8 logical and 4 physical cores
-    .NET SDK=7.0.100
-      [Host]     : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
-      Job-OVWNPR : .NET 6.0.11 (6.0.1122.52304), X64 RyuJIT AVX2
-      Job-KJBBGH : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
-      Job-CKYCTW : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
+    .NET SDK=7.0.101
+      [Host]     : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT AVX2
+      Job-GBHHXP : .NET 6.0.12 (6.0.1222.56807), X64 RyuJIT AVX2
+      Job-JZANEJ : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT AVX2
+      Job-JTAKIM : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT AVX2
 
 
-|                  Method |       Runtime | ObjectCount |         Mean |        Error |       StdDev |       Median | Ratio | RatioSD |       Gen0 |      Gen1 |      Gen2 |   Allocated | Alloc Ratio |
-|------------------------ |-------------- |------------ |-------------:|-------------:|-------------:|-------------:|------:|--------:|-----------:|----------:|----------:|------------:|------------:|
-|     JsonReaderBenchmark |      .NET 6.0 |          10 |     361.1 us |     11.90 us |     33.17 us |     353.0 us |  1.23 |    0.21 |    19.5313 |    5.8594 |         - |    83.67 KB |        0.85 |
-| SystemTextJsonBenchmark |      .NET 6.0 |          10 |     249.3 us |      4.98 us |     13.64 us |     248.7 us |  0.84 |    0.12 |    23.9258 |    7.8125 |         - |     98.9 KB |        1.01 |
-|     JsonReaderBenchmark |      .NET 7.0 |          10 |     327.6 us |     10.28 us |     29.32 us |     318.4 us |  1.12 |    0.19 |    20.0195 |    1.9531 |         - |    83.67 KB |        0.85 |
-| SystemTextJsonBenchmark |      .NET 7.0 |          10 |     285.3 us |     13.16 us |     35.79 us |     273.4 us |  0.96 |    0.18 |    23.9258 |    7.8125 |         - |    98.07 KB |        1.00 |
-|     JsonReaderBenchmark | NativeAOT 7.0 |          10 |     406.9 us |     34.08 us |     94.44 us |     371.2 us |  1.37 |    0.30 |    20.0195 |    1.9531 |         - |    83.67 KB |        0.85 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 |          10 |     298.6 us |     16.48 us |     46.50 us |     285.7 us |  1.00 |    0.00 |    23.9258 |    7.8125 |         - |    98.07 KB |        1.00 |
-|                         |               |             |              |              |              |              |       |         |            |           |           |             |             |
-|     JsonReaderBenchmark |      .NET 6.0 |         100 |   3,867.9 us |    164.67 us |    456.31 us |   3,714.0 us |  1.28 |    0.23 |   132.8125 |   66.4063 |         - |   834.32 KB |        0.85 |
-| SystemTextJsonBenchmark |      .NET 6.0 |         100 |   3,363.0 us |    219.58 us |    615.72 us |   3,143.9 us |  1.12 |    0.27 |   160.1563 |   78.1250 |         - |   994.96 KB |        1.01 |
-|     JsonReaderBenchmark |      .NET 7.0 |         100 |   3,781.9 us |    131.40 us |    374.89 us |   3,689.5 us |  1.25 |    0.22 |   132.8125 |  128.9063 |         - |   834.32 KB |        0.85 |
-| SystemTextJsonBenchmark |      .NET 7.0 |         100 |   3,047.9 us |    154.99 us |    439.68 us |   2,928.2 us |  0.99 |    0.19 |   160.1563 |  156.2500 |         - |   986.39 KB |        1.00 |
-|     JsonReaderBenchmark | NativeAOT 7.0 |         100 |   3,733.0 us |    165.12 us |    465.73 us |   3,628.0 us |  1.25 |    0.24 |   132.8125 |  125.0000 |         - |   834.32 KB |        0.85 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 |         100 |   3,085.3 us |    185.14 us |    503.69 us |   2,935.6 us |  1.00 |    0.00 |   160.1563 |  156.2500 |         - |   986.39 KB |        1.00 |
-|                         |               |             |              |              |              |              |       |         |            |           |           |             |             |
-|     JsonReaderBenchmark |      .NET 6.0 |        1000 |  48,127.1 us |  2,503.79 us |  7,102.84 us |  45,877.2 us |  0.98 |    0.21 |  1400.0000 |  500.0000 |  100.0000 |  8336.78 KB |        0.85 |
-| SystemTextJsonBenchmark |      .NET 6.0 |        1000 |  44,739.9 us |  1,663.72 us |  4,800.22 us |  43,065.2 us |  0.91 |    0.18 |  1727.2727 |  727.2727 |  272.7273 |  9875.11 KB |        1.01 |
-|     JsonReaderBenchmark |      .NET 7.0 |        1000 |  53,535.8 us |  3,335.49 us |  9,676.85 us |  49,938.4 us |  1.09 |    0.25 |  1555.5556 |  888.8889 |  222.2222 |  8336.96 KB |        0.85 |
-| SystemTextJsonBenchmark |      .NET 7.0 |        1000 |  45,374.4 us |  1,225.50 us |  3,516.18 us |  44,875.0 us |  0.92 |    0.16 |  1833.3333 | 1083.3333 |  333.3333 |  9789.81 KB |        1.00 |
-|     JsonReaderBenchmark | NativeAOT 7.0 |        1000 |  53,250.5 us |  2,668.28 us |  7,569.46 us |  50,447.6 us |  1.09 |    0.26 |  1500.0000 |  875.0000 |  250.0000 |  8337.59 KB |        0.85 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 |        1000 |  50,615.8 us |  3,317.44 us |  9,356.91 us |  48,137.7 us |  1.00 |    0.00 |  1818.1818 | 1000.0000 |  272.7273 |  9789.16 KB |        1.00 |
-|                         |               |             |              |              |              |              |       |         |            |           |           |             |             |
-|     JsonReaderBenchmark |      .NET 6.0 |       10000 | 473,801.2 us | 18,509.33 us | 51,902.14 us | 455,522.1 us |  1.24 |    0.19 | 13000.0000 | 5000.0000 |         - | 83459.95 KB |        0.86 |
-| SystemTextJsonBenchmark |      .NET 6.0 |       10000 | 402,131.6 us | 12,635.45 us | 36,049.65 us | 391,502.2 us |  1.05 |    0.12 | 15000.0000 | 5000.0000 |         - | 98321.43 KB |        1.01 |
-|     JsonReaderBenchmark |      .NET 7.0 |       10000 | 435,829.0 us | 13,578.17 us | 39,392.74 us | 421,647.1 us |  1.14 |    0.15 | 14000.0000 | 7000.0000 | 1000.0000 | 83460.31 KB |        0.86 |
-| SystemTextJsonBenchmark |      .NET 7.0 |       10000 | 378,523.2 us | 12,743.50 us | 37,173.38 us | 362,073.7 us |  1.00 |    0.15 | 16000.0000 | 8000.0000 | 1000.0000 |  97462.8 KB |        1.00 |
-|     JsonReaderBenchmark | NativeAOT 7.0 |       10000 | 430,449.1 us | 16,561.16 us | 47,249.91 us | 412,971.2 us |  1.13 |    0.17 | 14000.0000 | 7000.0000 | 1000.0000 | 83462.89 KB |        0.86 |
-| SystemTextJsonBenchmark | NativeAOT 7.0 |       10000 | 384,891.2 us | 14,468.88 us | 41,280.54 us | 367,407.8 us |  1.00 |    0.00 | 16000.0000 | 8000.0000 | 1000.0000 | 97462.79 KB |        1.00 |
+|                  Method |       Runtime | ObjectCount |           Mean |        Error |        StdDev |         Median | Ratio | RatioSD |       Gen0 |      Gen1 |      Gen2 |   Allocated | Alloc Ratio |
+|------------------------ |-------------- |------------ |---------------:|-------------:|--------------:|---------------:|------:|--------:|-----------:|----------:|----------:|------------:|------------:|
+|     JsonReaderBenchmark |      .NET 6.0 |          10 |       829.7 us |     32.92 us |      97.06 us |       814.4 us |  1.79 |    0.29 |    20.5078 |    1.9531 |         - |    84.61 KB |        0.86 |
+| SystemTextJsonBenchmark |      .NET 6.0 |          10 |       495.0 us |     19.81 us |      58.11 us |       488.3 us |  1.07 |    0.18 |    23.9258 |    7.8125 |         - |     98.9 KB |        1.01 |
+|     JsonReaderBenchmark |      .NET 7.0 |          10 |       763.3 us |     26.06 us |      75.18 us |       750.6 us |  1.64 |    0.24 |    20.5078 |    1.9531 |         - |    84.61 KB |        0.86 |
+| SystemTextJsonBenchmark |      .NET 7.0 |          10 |       437.4 us |     14.41 us |      42.02 us |       425.0 us |  0.94 |    0.13 |    23.4375 |    7.8125 |         - |    98.07 KB |        1.00 |
+|     JsonReaderBenchmark | NativeAOT 7.0 |          10 |       730.1 us |     20.06 us |      56.92 us |       731.0 us |  1.57 |    0.18 |    20.5078 |    1.9531 |         - |    84.61 KB |        0.86 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 |          10 |       469.7 us |     17.84 us |      50.32 us |       455.1 us |  1.00 |    0.00 |    23.9258 |    7.8125 |         - |    98.07 KB |        1.00 |
+|                         |               |             |                |              |               |                |       |         |            |           |           |             |             |
+|     JsonReaderBenchmark |      .NET 6.0 |         100 |     8,242.5 us |    230.19 us |     664.16 us |     8,186.2 us |  1.75 |    0.18 |   132.8125 |   62.5000 |         - |    843.7 KB |        0.86 |
+| SystemTextJsonBenchmark |      .NET 6.0 |         100 |     5,236.2 us |    204.64 us |     590.42 us |     5,115.8 us |  1.11 |    0.15 |   156.2500 |   78.1250 |         - |   994.96 KB |        1.01 |
+|     JsonReaderBenchmark |      .NET 7.0 |         100 |     7,875.5 us |    260.36 us |     755.36 us |     7,716.2 us |  1.67 |    0.21 |   132.8125 |  125.0000 |         - |    843.7 KB |        0.86 |
+| SystemTextJsonBenchmark |      .NET 7.0 |         100 |     4,802.9 us |    146.16 us |     426.35 us |     4,760.6 us |  1.02 |    0.11 |   156.2500 |  148.4375 |         - |    986.4 KB |        1.00 |
+|     JsonReaderBenchmark | NativeAOT 7.0 |         100 |     7,769.7 us |    254.58 us |     734.51 us |     7,622.5 us |  1.65 |    0.21 |   132.8125 |  125.0000 |         - |    843.7 KB |        0.86 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 |         100 |     4,752.8 us |    126.98 us |     368.39 us |     4,679.4 us |  1.00 |    0.00 |   156.2500 |  148.4375 |         - |    986.4 KB |        1.00 |
+|                         |               |             |                |              |               |                |       |         |            |           |           |             |             |
+|     JsonReaderBenchmark |      .NET 6.0 |        1000 |    91,705.6 us |  2,731.55 us |   7,924.72 us |    90,147.4 us |  1.18 |    0.26 |  1500.0000 |  666.6667 |  166.6667 |  8431.46 KB |        0.86 |
+| SystemTextJsonBenchmark |      .NET 6.0 |        1000 |    66,529.9 us |  2,066.72 us |   6,028.71 us |    65,676.7 us |  0.85 |    0.18 |  1777.7778 |  777.7778 |  222.2222 |  9875.75 KB |        1.01 |
+|     JsonReaderBenchmark |      .NET 7.0 |        1000 |    94,818.1 us |  3,732.08 us |  10,827.44 us |    92,959.7 us |  1.23 |    0.33 |  1400.0000 |  800.0000 |  200.0000 |  8431.39 KB |        0.86 |
+| SystemTextJsonBenchmark |      .NET 7.0 |        1000 |    71,909.2 us |  2,588.82 us |   7,510.64 us |    70,775.3 us |  0.93 |    0.21 |  1857.1429 | 1000.0000 |  285.7143 |  9789.17 KB |        1.00 |
+|     JsonReaderBenchmark | NativeAOT 7.0 |        1000 |    91,905.9 us |  3,260.01 us |   9,509.61 us |    89,695.9 us |  1.18 |    0.29 |  1500.0000 |  833.3333 |  166.6667 |  8430.87 KB |        0.86 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 |        1000 |    82,566.5 us |  6,914.74 us |  20,388.27 us |    72,473.2 us |  1.00 |    0.00 |  1750.0000 | 1000.0000 |  250.0000 |  9789.55 KB |        1.00 |
+|                         |               |             |                |              |               |                |       |         |            |           |           |             |             |
+|     JsonReaderBenchmark |      .NET 6.0 |       10000 | 1,092,464.8 us | 42,949.12 us | 125,284.58 us | 1,067,990.2 us |  1.16 |    0.31 | 13000.0000 | 5000.0000 |         - | 84397.45 KB |        0.87 |
+| SystemTextJsonBenchmark |      .NET 6.0 |       10000 |   634,041.7 us | 30,142.52 us |  87,927.16 us |   629,761.8 us |  0.68 |    0.23 | 15000.0000 | 5000.0000 |         - | 98321.43 KB |        1.01 |
+|     JsonReaderBenchmark |      .NET 7.0 |       10000 |   775,164.9 us | 31,426.50 us |  90,168.53 us |   750,062.1 us |  0.82 |    0.23 | 14000.0000 | 7000.0000 | 1000.0000 | 84397.85 KB |        0.87 |
+| SystemTextJsonBenchmark |      .NET 7.0 |       10000 |   533,456.7 us | 18,085.20 us |  52,468.43 us |   521,280.2 us |  0.57 |    0.16 | 16000.0000 | 8000.0000 | 1000.0000 |  97466.7 KB |        1.00 |
+|     JsonReaderBenchmark | NativeAOT 7.0 |       10000 | 1,066,155.4 us | 48,754.39 us | 142,218.84 us | 1,038,770.2 us |  1.13 |    0.33 | 14000.0000 | 7000.0000 | 1000.0000 |  84399.3 KB |        0.87 |
+| SystemTextJsonBenchmark | NativeAOT 7.0 |       10000 | 1,005,954.9 us | 83,038.53 us | 244,840.98 us | 1,008,079.6 us |  1.00 |    0.00 | 16000.0000 | 8000.0000 | 1000.0000 | 97462.72 KB |        1.00 |
 
   [GitHub REST API]: https://docs.github.com/en/rest/branches/branches#merge-a-branch

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -579,7 +579,8 @@ public static partial class JsonReader
 
             return Read(ref reader, sm, ref values);
 
-            JsonReadResult<TResult> Read(ref Utf8JsonReader reader, ObjectReadStateMachine sm, ref ObjectValueState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> values)
+            JsonReadResult<TResult> Read(ref Utf8JsonReader reader, ObjectReadStateMachine sm,
+                                         ref ObjectValueState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> values)
             {
                 while (true)
                 {
@@ -642,22 +643,22 @@ public static partial class JsonReader
                                 return true;
                             }
 
-                                 if (TrySetPropertyIndex(1,  property1,  ref reader, ref values)) { }
-                            else if (TrySetPropertyIndex(2,  property2,  ref reader, ref values)) { }
-                            else if (TrySetPropertyIndex(3,  property3,  ref reader, ref values)) { }
-                            else if (TrySetPropertyIndex(4,  property4,  ref reader, ref values)) { }
-                            else if (TrySetPropertyIndex(5,  property5,  ref reader, ref values)) { }
-                            else if (TrySetPropertyIndex(6,  property6,  ref reader, ref values)) { }
-                            else if (TrySetPropertyIndex(7,  property7,  ref reader, ref values)) { }
-                            else if (TrySetPropertyIndex(8,  property8,  ref reader, ref values)) { }
-                            else if (TrySetPropertyIndex(9,  property9,  ref reader, ref values)) { }
-                            else if (TrySetPropertyIndex(10, property10, ref reader, ref values)) { }
-                            else if (TrySetPropertyIndex(11, property11, ref reader, ref values)) { }
-                            else if (TrySetPropertyIndex(12, property12, ref reader, ref values)) { }
-                            else if (TrySetPropertyIndex(13, property13, ref reader, ref values)) { }
-                            else if (TrySetPropertyIndex(14, property14, ref reader, ref values)) { }
-                            else if (TrySetPropertyIndex(15, property15, ref reader, ref values)) { }
-                            else if (TrySetPropertyIndex(16, property16, ref reader, ref values)) { }
+                            _ =    TrySetPropertyIndex(1,  property1,  ref reader, ref values)
+                                || TrySetPropertyIndex(2,  property2,  ref reader, ref values)
+                                || TrySetPropertyIndex(3,  property3,  ref reader, ref values)
+                                || TrySetPropertyIndex(4,  property4,  ref reader, ref values)
+                                || TrySetPropertyIndex(5,  property5,  ref reader, ref values)
+                                || TrySetPropertyIndex(6,  property6,  ref reader, ref values)
+                                || TrySetPropertyIndex(7,  property7,  ref reader, ref values)
+                                || TrySetPropertyIndex(8,  property8,  ref reader, ref values)
+                                || TrySetPropertyIndex(9,  property9,  ref reader, ref values)
+                                || TrySetPropertyIndex(10, property10, ref reader, ref values)
+                                || TrySetPropertyIndex(11, property11, ref reader, ref values)
+                                || TrySetPropertyIndex(12, property12, ref reader, ref values)
+                                || TrySetPropertyIndex(13, property13, ref reader, ref values)
+                                || TrySetPropertyIndex(14, property14, ref reader, ref values)
+                                || TrySetPropertyIndex(15, property15, ref reader, ref values)
+                                || TrySetPropertyIndex(16, property16, ref reader, ref values);
 
                             if (!reader.Read())
                                 return reader.Suspend((sm, values));
@@ -705,11 +706,11 @@ public static partial class JsonReader
                                     14 => ReadPropertyValue(property14, ref reader, ref values.V14, ref sm, ref values),
                                     15 => ReadPropertyValue(property15, ref reader, ref values.V15, ref sm, ref values),
                                     16 => ReadPropertyValue(property16, ref reader, ref values.V16, ref sm, ref values),
-                                    _ => throw new InvalidOperationException()
+                                    var i => throw new SwitchExpressionException(i)
                                 };
 
-                                if (error is not null)
-                                    return error.Value;
+                                if (error is { } someResult)
+                                    return someResult;
                             }
                             else
                             {

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -592,45 +592,8 @@ public static partial class JsonReader
                         case ObjectReadStateMachine.ReadResult.Incomplete:
                             return reader.Suspend((sm, state));
 
-                        case ObjectReadStateMachine.ReadResult.Done:
-                            static void DefaultUnassigned<T>(IJsonProperty<T, JsonReadResult<T>> property, ref (bool, T) v)
-                            {
-                                if (v is (false, _) && property.HasDefaultValue)
-                                    v = (true, property.DefaultValue);
-                            }
-
-                            DefaultUnassigned(property1,  ref state.V1);
-                            DefaultUnassigned(property2,  ref state.V2);
-                            DefaultUnassigned(property3,  ref state.V3);
-                            DefaultUnassigned(property4,  ref state.V4);
-                            DefaultUnassigned(property5,  ref state.V5);
-                            DefaultUnassigned(property6,  ref state.V6);
-                            DefaultUnassigned(property7,  ref state.V7);
-                            DefaultUnassigned(property8,  ref state.V8);
-                            DefaultUnassigned(property9,  ref state.V9);
-                            DefaultUnassigned(property10, ref state.V10);
-                            DefaultUnassigned(property11, ref state.V11);
-                            DefaultUnassigned(property12, ref state.V12);
-                            DefaultUnassigned(property13, ref state.V13);
-                            DefaultUnassigned(property14, ref state.V14);
-                            DefaultUnassigned(property15, ref state.V15);
-                            DefaultUnassigned(property16, ref state.V16);
-
-                            return (state.V1, state.V2, state.V3,
-                                    state.V4, state.V5, state.V6,
-                                    state.V7, state.V8, state.V9,
-                                    state.V10, state.V11, state.V12,
-                                    state.V13, state.V14, state.V15,
-                                    state.V16) is ((true, var v1), (true, var v2), (true, var v3),
-                                                    (true, var v4), (true, var v5), (true, var v6),
-                                                    (true, var v7), (true, var v8), (true, var v9),
-                                                    (true, var v10), (true, var v11), (true, var v12),
-                                                    (true, var v13), (true, var v14), (true, var v15),
-                                                    (true, var v16))
-                                 ? Value(projector(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16))
-                                 : Error("Invalid JSON object.");
-
                         case ObjectReadStateMachine.ReadResult.PropertyName:
+                        {
                             static bool TrySetPropertyIndex<T>(int index,
                                                                IJsonProperty<T, JsonReadResult<T>> property,
                                                                ref Utf8JsonReader reader,
@@ -666,8 +629,10 @@ public static partial class JsonReader
                             sm.OnPropertyNameRead();
 
                             break;
+                        }
 
                         case ObjectReadStateMachine.ReadResult.PropertyValue:
+                        {
                             static JsonReadResult<TResult>? ReadPropertyValue<T>(ref Utf8JsonReader reader,
                                                                                  IJsonProperty<T, JsonReadResult<T>> property,
                                                                                  ref (bool, T) value,
@@ -724,6 +689,47 @@ public static partial class JsonReader
                             state.CurrentPropertyIndex = null;
 
                             break;
+                        }
+
+                        case ObjectReadStateMachine.ReadResult.Done:
+                        {
+                            static void DefaultUnassigned<T>(IJsonProperty<T, JsonReadResult<T>> property, ref (bool, T) v)
+                            {
+                                if (v is (false, _) && property.HasDefaultValue)
+                                    v = (true, property.DefaultValue);
+                            }
+
+                            DefaultUnassigned(property1, ref state.V1);
+                            DefaultUnassigned(property2, ref state.V2);
+                            DefaultUnassigned(property3, ref state.V3);
+                            DefaultUnassigned(property4, ref state.V4);
+                            DefaultUnassigned(property5, ref state.V5);
+                            DefaultUnassigned(property6, ref state.V6);
+                            DefaultUnassigned(property7, ref state.V7);
+                            DefaultUnassigned(property8, ref state.V8);
+                            DefaultUnassigned(property9, ref state.V9);
+                            DefaultUnassigned(property10, ref state.V10);
+                            DefaultUnassigned(property11, ref state.V11);
+                            DefaultUnassigned(property12, ref state.V12);
+                            DefaultUnassigned(property13, ref state.V13);
+                            DefaultUnassigned(property14, ref state.V14);
+                            DefaultUnassigned(property15, ref state.V15);
+                            DefaultUnassigned(property16, ref state.V16);
+
+                            return (state.V1, state.V2, state.V3,
+                                    state.V4, state.V5, state.V6,
+                                    state.V7, state.V8, state.V9,
+                                    state.V10, state.V11, state.V12,
+                                    state.V13, state.V14, state.V15,
+                                    state.V16) is ((true, var v1), (true, var v2), (true, var v3),
+                                                    (true, var v4), (true, var v5), (true, var v6),
+                                                    (true, var v7), (true, var v8), (true, var v9),
+                                                    (true, var v10), (true, var v11), (true, var v12),
+                                                    (true, var v13), (true, var v14), (true, var v15),
+                                                    (true, var v16))
+                                 ? Value(projector(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16))
+                                 : Error("Invalid JSON object.");
+                        }
                     }
                 }
             }

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -645,15 +645,15 @@ public static partial class JsonReader
                                 Debug.Assert(read);
                             }
 
-                            if (SetPropertyIndex(1, property1, ref reader, ref values)) { }
-                            else if (SetPropertyIndex(2, property2, ref reader, ref values)) { }
-                            else if (SetPropertyIndex(3, property3, ref reader, ref values)) { }
-                            else if (SetPropertyIndex(4, property4, ref reader, ref values)) { }
-                            else if (SetPropertyIndex(5, property5, ref reader, ref values)) { }
-                            else if (SetPropertyIndex(6, property6, ref reader, ref values)) { }
-                            else if (SetPropertyIndex(7, property7, ref reader, ref values)) { }
-                            else if (SetPropertyIndex(8, property8, ref reader, ref values)) { }
-                            else if (SetPropertyIndex(9, property9, ref reader, ref values)) { }
+                                 if (SetPropertyIndex(1,  property1,  ref reader, ref values)) { }
+                            else if (SetPropertyIndex(2,  property2,  ref reader, ref values)) { }
+                            else if (SetPropertyIndex(3,  property3,  ref reader, ref values)) { }
+                            else if (SetPropertyIndex(4,  property4,  ref reader, ref values)) { }
+                            else if (SetPropertyIndex(5,  property5,  ref reader, ref values)) { }
+                            else if (SetPropertyIndex(6,  property6,  ref reader, ref values)) { }
+                            else if (SetPropertyIndex(7,  property7,  ref reader, ref values)) { }
+                            else if (SetPropertyIndex(8,  property8,  ref reader, ref values)) { }
+                            else if (SetPropertyIndex(9,  property9,  ref reader, ref values)) { }
                             else if (SetPropertyIndex(10, property10, ref reader, ref values)) { }
                             else if (SetPropertyIndex(11, property11, ref reader, ref values)) { }
                             else if (SetPropertyIndex(12, property12, ref reader, ref values)) { }

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -594,34 +594,36 @@ public static partial class JsonReader
 
                         case ObjectReadStateMachine.ReadResult.PropertyName:
                         {
-                            static bool TrySetPropertyIndex<T>(int index,
-                                                               IJsonProperty<T, JsonReadResult<T>> property,
-                                                               ref Utf8JsonReader reader,
-                                                               ref ObjectReadState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> state)
+                            static bool TrySetPropertyIndex<TValue>(int index,
+                                                                    IJsonProperty<TValue, JsonReadResult<TValue>> property,
+                                                                    ref Utf8JsonReader reader,
+                                                                    ref int? currentIndex)
                             {
                                 if (!property.IsMatch(ref reader))
                                     return false;
 
-                                state.CurrentPropertyIndex = index;
+                                currentIndex = index;
                                 return true;
                             }
 
-                            _ =    TrySetPropertyIndex(1,  property1,  ref reader, ref state)
-                                || TrySetPropertyIndex(2,  property2,  ref reader, ref state)
-                                || TrySetPropertyIndex(3,  property3,  ref reader, ref state)
-                                || TrySetPropertyIndex(4,  property4,  ref reader, ref state)
-                                || TrySetPropertyIndex(5,  property5,  ref reader, ref state)
-                                || TrySetPropertyIndex(6,  property6,  ref reader, ref state)
-                                || TrySetPropertyIndex(7,  property7,  ref reader, ref state)
-                                || TrySetPropertyIndex(8,  property8,  ref reader, ref state)
-                                || TrySetPropertyIndex(9,  property9,  ref reader, ref state)
-                                || TrySetPropertyIndex(10, property10, ref reader, ref state)
-                                || TrySetPropertyIndex(11, property11, ref reader, ref state)
-                                || TrySetPropertyIndex(12, property12, ref reader, ref state)
-                                || TrySetPropertyIndex(13, property13, ref reader, ref state)
-                                || TrySetPropertyIndex(14, property14, ref reader, ref state)
-                                || TrySetPropertyIndex(15, property15, ref reader, ref state)
-                                || TrySetPropertyIndex(16, property16, ref reader, ref state);
+                            ref var currentPropertyIndex = ref state.CurrentPropertyIndex;
+
+                            _ =    TrySetPropertyIndex(1,  property1,  ref reader, ref currentPropertyIndex)
+                                || TrySetPropertyIndex(2,  property2,  ref reader, ref currentPropertyIndex)
+                                || TrySetPropertyIndex(3,  property3,  ref reader, ref currentPropertyIndex)
+                                || TrySetPropertyIndex(4,  property4,  ref reader, ref currentPropertyIndex)
+                                || TrySetPropertyIndex(5,  property5,  ref reader, ref currentPropertyIndex)
+                                || TrySetPropertyIndex(6,  property6,  ref reader, ref currentPropertyIndex)
+                                || TrySetPropertyIndex(7,  property7,  ref reader, ref currentPropertyIndex)
+                                || TrySetPropertyIndex(8,  property8,  ref reader, ref currentPropertyIndex)
+                                || TrySetPropertyIndex(9,  property9,  ref reader, ref currentPropertyIndex)
+                                || TrySetPropertyIndex(10, property10, ref reader, ref currentPropertyIndex)
+                                || TrySetPropertyIndex(11, property11, ref reader, ref currentPropertyIndex)
+                                || TrySetPropertyIndex(12, property12, ref reader, ref currentPropertyIndex)
+                                || TrySetPropertyIndex(13, property13, ref reader, ref currentPropertyIndex)
+                                || TrySetPropertyIndex(14, property14, ref reader, ref currentPropertyIndex)
+                                || TrySetPropertyIndex(15, property15, ref reader, ref currentPropertyIndex)
+                                || TrySetPropertyIndex(16, property16, ref reader, ref currentPropertyIndex);
 
                             if (!reader.Read())
                                 return reader.Suspend((sm, state));

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -672,7 +672,7 @@ public static partial class JsonReader
                                                                                  ref Utf8JsonReader reader,
                                                                                  ref (bool, T) value,
                                                                                  ref ObjectReadStateMachine sm,
-                                                                                 ref ObjectReadState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> state)
+                                                                                 in ObjectReadState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> state)
                             {
                                 switch (property.Reader.TryRead(ref reader))
                                 {
@@ -690,22 +690,22 @@ public static partial class JsonReader
                             {
                                 var result = nextPropertyIndex switch
                                 {
-                                    1  => ReadPropertyValue(property1,  ref reader, ref state.V1,  ref sm, ref state),
-                                    2  => ReadPropertyValue(property2,  ref reader, ref state.V2,  ref sm, ref state),
-                                    3  => ReadPropertyValue(property3,  ref reader, ref state.V3,  ref sm, ref state),
-                                    4  => ReadPropertyValue(property4,  ref reader, ref state.V4,  ref sm, ref state),
-                                    5  => ReadPropertyValue(property5,  ref reader, ref state.V5,  ref sm, ref state),
-                                    6  => ReadPropertyValue(property6,  ref reader, ref state.V6,  ref sm, ref state),
-                                    7  => ReadPropertyValue(property7,  ref reader, ref state.V7,  ref sm, ref state),
-                                    8  => ReadPropertyValue(property8,  ref reader, ref state.V8,  ref sm, ref state),
-                                    9  => ReadPropertyValue(property9,  ref reader, ref state.V9,  ref sm, ref state),
-                                    10 => ReadPropertyValue(property10, ref reader, ref state.V10, ref sm, ref state),
-                                    11 => ReadPropertyValue(property11, ref reader, ref state.V11, ref sm, ref state),
-                                    12 => ReadPropertyValue(property12, ref reader, ref state.V12, ref sm, ref state),
-                                    13 => ReadPropertyValue(property13, ref reader, ref state.V13, ref sm, ref state),
-                                    14 => ReadPropertyValue(property14, ref reader, ref state.V14, ref sm, ref state),
-                                    15 => ReadPropertyValue(property15, ref reader, ref state.V15, ref sm, ref state),
-                                    16 => ReadPropertyValue(property16, ref reader, ref state.V16, ref sm, ref state),
+                                    1  => ReadPropertyValue(property1,  ref reader, ref state.V1,  ref sm, in state),
+                                    2  => ReadPropertyValue(property2,  ref reader, ref state.V2,  ref sm, in state),
+                                    3  => ReadPropertyValue(property3,  ref reader, ref state.V3,  ref sm, in state),
+                                    4  => ReadPropertyValue(property4,  ref reader, ref state.V4,  ref sm, in state),
+                                    5  => ReadPropertyValue(property5,  ref reader, ref state.V5,  ref sm, in state),
+                                    6  => ReadPropertyValue(property6,  ref reader, ref state.V6,  ref sm, in state),
+                                    7  => ReadPropertyValue(property7,  ref reader, ref state.V7,  ref sm, in state),
+                                    8  => ReadPropertyValue(property8,  ref reader, ref state.V8,  ref sm, in state),
+                                    9  => ReadPropertyValue(property9,  ref reader, ref state.V9,  ref sm, in state),
+                                    10 => ReadPropertyValue(property10, ref reader, ref state.V10, ref sm, in state),
+                                    11 => ReadPropertyValue(property11, ref reader, ref state.V11, ref sm, in state),
+                                    12 => ReadPropertyValue(property12, ref reader, ref state.V12, ref sm, in state),
+                                    13 => ReadPropertyValue(property13, ref reader, ref state.V13, ref sm, in state),
+                                    14 => ReadPropertyValue(property14, ref reader, ref state.V14, ref sm, in state),
+                                    15 => ReadPropertyValue(property15, ref reader, ref state.V15, ref sm, in state),
+                                    16 => ReadPropertyValue(property16, ref reader, ref state.V16, ref sm, in state),
                                     var i => throw new SwitchExpressionException(i)
                                 };
 

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -630,7 +630,10 @@ public static partial class JsonReader
                                  : Error("Invalid JSON object.");
 
                         case ObjectReadStateMachine.ReadResult.PropertyName:
-                            static bool SetPropertyIndex<TValue>(int index, IJsonProperty<TValue, JsonReadResult<TValue>> property, ref Utf8JsonReader reader, ref Values<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> values)
+                            static bool SetPropertyIndex<TValue>(int index,
+                                                                 IJsonProperty<TValue, JsonReadResult<TValue>> property,
+                                                                 ref Utf8JsonReader reader,
+                                                                 ref Values<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> values)
                             {
                                 if (!property.IsMatch(ref reader))
                                     return false;
@@ -670,23 +673,21 @@ public static partial class JsonReader
                             break;
 
                         case ObjectReadStateMachine.ReadResult.PropertyValue:
-                            bool ReadPropertyValue<TValue>(IJsonProperty<TValue, JsonReadResult<TValue>> property,
-                                                           ref Utf8JsonReader reader,
-                                                           ref (bool, TValue) value,
-                                                           out JsonReadResult<TResult>? jsonReadResult)
+                            static JsonReadResult<TResult>? ReadPropertyValue<TValue>(IJsonProperty<TValue, JsonReadResult<TValue>> property,
+                                                                                      ref Utf8JsonReader reader,
+                                                                                      ref (bool, TValue) value,
+                                                                                      ref ObjectReadStateMachine sm,
+                                                                                      ref Values<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> values)
                             {
                                 switch (property.Reader.TryRead(ref reader))
                                 {
                                     case { Incomplete: true }:
-                                        jsonReadResult = reader.Suspend((sm, values));
-                                        return false;
+                                        return reader.Suspend((sm, values));
                                     case { Error: { } err }:
-                                        jsonReadResult = new JsonReadError(err);
-                                        return false;
+                                        return new JsonReadError(err);
                                     case { Value: var val }:
                                         value = (true, val);
-                                        jsonReadResult = null;
-                                        return true;
+                                        return null;
                                 }
                             }
 
@@ -698,29 +699,29 @@ public static partial class JsonReader
                                     return reader.Suspend((sm, values));
                             }
 
-                            var (valueRead, error) = values.NextPropertyIndex switch
+                            var error = values.NextPropertyIndex switch
                             {
-                                1  => (ReadPropertyValue(property1,  ref reader, ref values.P1,  out var e), e),
-                                2  => (ReadPropertyValue(property2,  ref reader, ref values.P2,  out var e), e),
-                                3  => (ReadPropertyValue(property3,  ref reader, ref values.P3,  out var e), e),
-                                4  => (ReadPropertyValue(property4,  ref reader, ref values.P4,  out var e), e),
-                                5  => (ReadPropertyValue(property5,  ref reader, ref values.P5,  out var e), e),
-                                6  => (ReadPropertyValue(property6,  ref reader, ref values.P6,  out var e), e),
-                                7  => (ReadPropertyValue(property7,  ref reader, ref values.P7,  out var e), e),
-                                8  => (ReadPropertyValue(property8,  ref reader, ref values.P8,  out var e), e),
-                                9  => (ReadPropertyValue(property9,  ref reader, ref values.P9,  out var e), e),
-                                10 => (ReadPropertyValue(property10, ref reader, ref values.P10, out var e), e),
-                                11 => (ReadPropertyValue(property11, ref reader, ref values.P11, out var e), e),
-                                12 => (ReadPropertyValue(property12, ref reader, ref values.P12, out var e), e),
-                                13 => (ReadPropertyValue(property13, ref reader, ref values.P13, out var e), e),
-                                14 => (ReadPropertyValue(property14, ref reader, ref values.P14, out var e), e),
-                                15 => (ReadPropertyValue(property15, ref reader, ref values.P15, out var e), e),
-                                16 => (ReadPropertyValue(property16, ref reader, ref values.P16, out var e), e),
-                                null => (true, null),
+                                1  => ReadPropertyValue(property1,  ref reader, ref values.P1,  ref sm, ref values),
+                                2  => ReadPropertyValue(property2,  ref reader, ref values.P2,  ref sm, ref values),
+                                3  => ReadPropertyValue(property3,  ref reader, ref values.P3,  ref sm, ref values),
+                                4  => ReadPropertyValue(property4,  ref reader, ref values.P4,  ref sm, ref values),
+                                5  => ReadPropertyValue(property5,  ref reader, ref values.P5,  ref sm, ref values),
+                                6  => ReadPropertyValue(property6,  ref reader, ref values.P6,  ref sm, ref values),
+                                7  => ReadPropertyValue(property7,  ref reader, ref values.P7,  ref sm, ref values),
+                                8  => ReadPropertyValue(property8,  ref reader, ref values.P8,  ref sm, ref values),
+                                9  => ReadPropertyValue(property9,  ref reader, ref values.P9,  ref sm, ref values),
+                                10 => ReadPropertyValue(property10, ref reader, ref values.P10, ref sm, ref values),
+                                11 => ReadPropertyValue(property11, ref reader, ref values.P11, ref sm, ref values),
+                                12 => ReadPropertyValue(property12, ref reader, ref values.P12, ref sm, ref values),
+                                13 => ReadPropertyValue(property13, ref reader, ref values.P13, ref sm, ref values),
+                                14 => ReadPropertyValue(property14, ref reader, ref values.P14, ref sm, ref values),
+                                15 => ReadPropertyValue(property15, ref reader, ref values.P15, ref sm, ref values),
+                                16 => ReadPropertyValue(property16, ref reader, ref values.P16, ref sm, ref values),
+                                null => null,
                                 _  => throw new InvalidOperationException()
                             };
 
-                            if (!valueRead && error is not null)
+                            if (error is not null)
                                 return error.Value;
 
                             sm.OnPropertyValueRead();

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -644,9 +644,9 @@ public static partial class JsonReader
                                 }
                             }
 
-                            if (state.CurrentPropertyIndex is { } nextPropertyIndex)
+                            if (state.CurrentPropertyIndex is { } propertyIndex)
                             {
-                                var result = nextPropertyIndex switch
+                                var result = propertyIndex switch
                                 {
                                     1  => ReadPropertyValue(ref reader, property1,  ref state.Value1,  ref sm, state),
                                     2  => ReadPropertyValue(ref reader, property2,  ref state.Value2,  ref sm, state),
@@ -664,7 +664,6 @@ public static partial class JsonReader
                                     14 => ReadPropertyValue(ref reader, property14, ref state.Value14, ref sm, state),
                                     15 => ReadPropertyValue(ref reader, property15, ref state.Value15, ref sm, state),
                                     16 => ReadPropertyValue(ref reader, property16, ref state.Value16, ref sm, state),
-                                    var i => throw new SwitchExpressionException(i)
                                     var i => throw new SwitchExpressionException(i)
                                 };
 

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -535,22 +535,22 @@ public static partial class JsonReader
 
     struct ObjectReadState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>
     {
-        public (bool, T1) V1;
-        public (bool, T2) V2;
-        public (bool, T3) V3;
-        public (bool, T4) V4;
-        public (bool, T5) V5;
-        public (bool, T6) V6;
-        public (bool, T7) V7;
-        public (bool, T8) V8;
-        public (bool, T9) V9;
-        public (bool, T10) V10;
-        public (bool, T11) V11;
-        public (bool, T12) V12;
-        public (bool, T13) V13;
-        public (bool, T14) V14;
-        public (bool, T15) V15;
-        public (bool, T16) V16;
+        public (bool, T1) Value1;
+        public (bool, T2) Value2;
+        public (bool, T3) Value3;
+        public (bool, T4) Value4;
+        public (bool, T5) Value5;
+        public (bool, T6) Value6;
+        public (bool, T7) Value7;
+        public (bool, T8) Value8;
+        public (bool, T9) Value9;
+        public (bool, T10) Value10;
+        public (bool, T11) Value11;
+        public (bool, T12) Value12;
+        public (bool, T13) Value13;
+        public (bool, T14) Value14;
+        public (bool, T15) Value15;
+        public (bool, T16) Value16;
 
         public int? CurrentPropertyIndex;
     };
@@ -655,22 +655,22 @@ public static partial class JsonReader
                             {
                                 var result = nextPropertyIndex switch
                                 {
-                                    1  => ReadPropertyValue(ref reader, property1,  ref state.V1,  ref sm, in state),
-                                    2  => ReadPropertyValue(ref reader, property2,  ref state.V2,  ref sm, in state),
-                                    3  => ReadPropertyValue(ref reader, property3,  ref state.V3,  ref sm, in state),
-                                    4  => ReadPropertyValue(ref reader, property4,  ref state.V4,  ref sm, in state),
-                                    5  => ReadPropertyValue(ref reader, property5,  ref state.V5,  ref sm, in state),
-                                    6  => ReadPropertyValue(ref reader, property6,  ref state.V6,  ref sm, in state),
-                                    7  => ReadPropertyValue(ref reader, property7,  ref state.V7,  ref sm, in state),
-                                    8  => ReadPropertyValue(ref reader, property8,  ref state.V8,  ref sm, in state),
-                                    9  => ReadPropertyValue(ref reader, property9,  ref state.V9,  ref sm, in state),
-                                    10 => ReadPropertyValue(ref reader, property10, ref state.V10, ref sm, in state),
-                                    11 => ReadPropertyValue(ref reader, property11, ref state.V11, ref sm, in state),
-                                    12 => ReadPropertyValue(ref reader, property12, ref state.V12, ref sm, in state),
-                                    13 => ReadPropertyValue(ref reader, property13, ref state.V13, ref sm, in state),
-                                    14 => ReadPropertyValue(ref reader, property14, ref state.V14, ref sm, in state),
-                                    15 => ReadPropertyValue(ref reader, property15, ref state.V15, ref sm, in state),
-                                    16 => ReadPropertyValue(ref reader, property16, ref state.V16, ref sm, in state),
+                                    1  => ReadPropertyValue(ref reader, property1,  ref state.Value1,  ref sm, in state),
+                                    2  => ReadPropertyValue(ref reader, property2,  ref state.Value2,  ref sm, in state),
+                                    3  => ReadPropertyValue(ref reader, property3,  ref state.Value3,  ref sm, in state),
+                                    4  => ReadPropertyValue(ref reader, property4,  ref state.Value4,  ref sm, in state),
+                                    5  => ReadPropertyValue(ref reader, property5,  ref state.Value5,  ref sm, in state),
+                                    6  => ReadPropertyValue(ref reader, property6,  ref state.Value6,  ref sm, in state),
+                                    7  => ReadPropertyValue(ref reader, property7,  ref state.Value7,  ref sm, in state),
+                                    8  => ReadPropertyValue(ref reader, property8,  ref state.Value8,  ref sm, in state),
+                                    9  => ReadPropertyValue(ref reader, property9,  ref state.Value9,  ref sm, in state),
+                                    10 => ReadPropertyValue(ref reader, property10, ref state.Value10, ref sm, in state),
+                                    11 => ReadPropertyValue(ref reader, property11, ref state.Value11, ref sm, in state),
+                                    12 => ReadPropertyValue(ref reader, property12, ref state.Value12, ref sm, in state),
+                                    13 => ReadPropertyValue(ref reader, property13, ref state.Value13, ref sm, in state),
+                                    14 => ReadPropertyValue(ref reader, property14, ref state.Value14, ref sm, in state),
+                                    15 => ReadPropertyValue(ref reader, property15, ref state.Value15, ref sm, in state),
+                                    16 => ReadPropertyValue(ref reader, property16, ref state.Value16, ref sm, in state),
                                     var i => throw new SwitchExpressionException(i)
                                 };
 
@@ -699,29 +699,29 @@ public static partial class JsonReader
                                     v = (true, property.DefaultValue);
                             }
 
-                            DefaultUnassigned(property1, ref state.V1);
-                            DefaultUnassigned(property2, ref state.V2);
-                            DefaultUnassigned(property3, ref state.V3);
-                            DefaultUnassigned(property4, ref state.V4);
-                            DefaultUnassigned(property5, ref state.V5);
-                            DefaultUnassigned(property6, ref state.V6);
-                            DefaultUnassigned(property7, ref state.V7);
-                            DefaultUnassigned(property8, ref state.V8);
-                            DefaultUnassigned(property9, ref state.V9);
-                            DefaultUnassigned(property10, ref state.V10);
-                            DefaultUnassigned(property11, ref state.V11);
-                            DefaultUnassigned(property12, ref state.V12);
-                            DefaultUnassigned(property13, ref state.V13);
-                            DefaultUnassigned(property14, ref state.V14);
-                            DefaultUnassigned(property15, ref state.V15);
-                            DefaultUnassigned(property16, ref state.V16);
+                            DefaultUnassigned(property1, ref state.Value1);
+                            DefaultUnassigned(property2, ref state.Value2);
+                            DefaultUnassigned(property3, ref state.Value3);
+                            DefaultUnassigned(property4, ref state.Value4);
+                            DefaultUnassigned(property5, ref state.Value5);
+                            DefaultUnassigned(property6, ref state.Value6);
+                            DefaultUnassigned(property7, ref state.Value7);
+                            DefaultUnassigned(property8, ref state.Value8);
+                            DefaultUnassigned(property9, ref state.Value9);
+                            DefaultUnassigned(property10, ref state.Value10);
+                            DefaultUnassigned(property11, ref state.Value11);
+                            DefaultUnassigned(property12, ref state.Value12);
+                            DefaultUnassigned(property13, ref state.Value13);
+                            DefaultUnassigned(property14, ref state.Value14);
+                            DefaultUnassigned(property15, ref state.Value15);
+                            DefaultUnassigned(property16, ref state.Value16);
 
-                            return (state.V1, state.V2, state.V3,
-                                    state.V4, state.V5, state.V6,
-                                    state.V7, state.V8, state.V9,
-                                    state.V10, state.V11, state.V12,
-                                    state.V13, state.V14, state.V15,
-                                    state.V16) is ((true, var v1), (true, var v2), (true, var v3),
+                            return (state.Value1, state.Value2, state.Value3,
+                                    state.Value4, state.Value5, state.Value6,
+                                    state.Value7, state.Value8, state.Value9,
+                                    state.Value10, state.Value11, state.Value12,
+                                    state.Value13, state.Value14, state.Value15,
+                                    state.Value16) is ((true, var v1), (true, var v2), (true, var v3),
                                                     (true, var v4), (true, var v5), (true, var v6),
                                                     (true, var v7), (true, var v8), (true, var v9),
                                                     (true, var v10), (true, var v11), (true, var v12),

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -642,12 +642,6 @@ public static partial class JsonReader
                                 return true;
                             }
 
-                            if (sm.CurrentPropertyLoopCount is 0)
-                            {
-                                var read = reader.Read();
-                                Debug.Assert(read);
-                            }
-
                                  if (TrySetPropertyIndex(1,  property1,  ref reader, ref values)) { }
                             else if (TrySetPropertyIndex(2,  property2,  ref reader, ref values)) { }
                             else if (TrySetPropertyIndex(3,  property3,  ref reader, ref values)) { }

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -629,7 +629,7 @@ public static partial class JsonReader
                             static JsonReadResult<TResult>? ReadPropertyValue<T>(ref Utf8JsonReader reader,
                                                                                  IJsonProperty<T, JsonReadResult<T>> property,
                                                                                  ref (bool, T) value,
-                                                                                 ref ObjectReadStateMachine sm,
+                                                                                 in ObjectReadStateMachine sm,
                                                                                  in ObjectReadState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> state)
                             {
                                 switch (property.Reader.TryRead(ref reader))
@@ -648,23 +648,22 @@ public static partial class JsonReader
                             {
                                 var result = nextPropertyIndex switch
                                 {
-                                    1  => ReadPropertyValue(ref reader, property1,  ref state.Value1,  ref sm, state),
-                                    2  => ReadPropertyValue(ref reader, property2,  ref state.Value2,  ref sm, state),
-                                    3  => ReadPropertyValue(ref reader, property3,  ref state.Value3,  ref sm, state),
-                                    4  => ReadPropertyValue(ref reader, property4,  ref state.Value4,  ref sm, state),
-                                    5  => ReadPropertyValue(ref reader, property5,  ref state.Value5,  ref sm, state),
-                                    6  => ReadPropertyValue(ref reader, property6,  ref state.Value6,  ref sm, state),
-                                    7  => ReadPropertyValue(ref reader, property7,  ref state.Value7,  ref sm, state),
-                                    8  => ReadPropertyValue(ref reader, property8,  ref state.Value8,  ref sm, state),
-                                    9  => ReadPropertyValue(ref reader, property9,  ref state.Value9,  ref sm, state),
-                                    10 => ReadPropertyValue(ref reader, property10, ref state.Value10, ref sm, state),
-                                    11 => ReadPropertyValue(ref reader, property11, ref state.Value11, ref sm, state),
-                                    12 => ReadPropertyValue(ref reader, property12, ref state.Value12, ref sm, state),
-                                    13 => ReadPropertyValue(ref reader, property13, ref state.Value13, ref sm, state),
-                                    14 => ReadPropertyValue(ref reader, property14, ref state.Value14, ref sm, state),
-                                    15 => ReadPropertyValue(ref reader, property15, ref state.Value15, ref sm, state),
-                                    16 => ReadPropertyValue(ref reader, property16, ref state.Value16, ref sm, state),
-                                    var i => throw new SwitchExpressionException(i)
+                                    1  => ReadPropertyValue(ref reader, property1,  ref state.Value1,  sm, state),
+                                    2  => ReadPropertyValue(ref reader, property2,  ref state.Value2,  sm, state),
+                                    3  => ReadPropertyValue(ref reader, property3,  ref state.Value3,  sm, state),
+                                    4  => ReadPropertyValue(ref reader, property4,  ref state.Value4,  sm, state),
+                                    5  => ReadPropertyValue(ref reader, property5,  ref state.Value5,  sm, state),
+                                    6  => ReadPropertyValue(ref reader, property6,  ref state.Value6,  sm, state),
+                                    7  => ReadPropertyValue(ref reader, property7,  ref state.Value7,  sm, state),
+                                    8  => ReadPropertyValue(ref reader, property8,  ref state.Value8,  sm, state),
+                                    9  => ReadPropertyValue(ref reader, property9,  ref state.Value9,  sm, state),
+                                    10 => ReadPropertyValue(ref reader, property10, ref state.Value10, sm, state),
+                                    11 => ReadPropertyValue(ref reader, property11, ref state.Value11, sm, state),
+                                    12 => ReadPropertyValue(ref reader, property12, ref state.Value12, sm, state),
+                                    13 => ReadPropertyValue(ref reader, property13, ref state.Value13, sm, state),
+                                    14 => ReadPropertyValue(ref reader, property14, ref state.Value14, sm, state),
+                                    15 => ReadPropertyValue(ref reader, property15, ref state.Value15, sm, state),
+                                    16 => ReadPropertyValue(ref reader, property16, ref state.Value16, sm, state),
                                     var i => throw new SwitchExpressionException(i)
                                 };
 

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -630,10 +630,10 @@ public static partial class JsonReader
                                  : Error("Invalid JSON object.");
 
                         case ObjectReadStateMachine.ReadResult.PropertyName:
-                            static bool SetPropertyIndex<TValue>(int index,
-                                                                 IJsonProperty<TValue, JsonReadResult<TValue>> property,
-                                                                 ref Utf8JsonReader reader,
-                                                                 ref Values<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> values)
+                            static bool TrySetPropertyIndex<TValue>(int index,
+                                                                    IJsonProperty<TValue, JsonReadResult<TValue>> property,
+                                                                    ref Utf8JsonReader reader,
+                                                                    ref Values<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> values)
                             {
                                 if (!property.IsMatch(ref reader))
                                     return false;
@@ -648,22 +648,22 @@ public static partial class JsonReader
                                 Debug.Assert(read);
                             }
 
-                                 if (SetPropertyIndex(1,  property1,  ref reader, ref values)) { }
-                            else if (SetPropertyIndex(2,  property2,  ref reader, ref values)) { }
-                            else if (SetPropertyIndex(3,  property3,  ref reader, ref values)) { }
-                            else if (SetPropertyIndex(4,  property4,  ref reader, ref values)) { }
-                            else if (SetPropertyIndex(5,  property5,  ref reader, ref values)) { }
-                            else if (SetPropertyIndex(6,  property6,  ref reader, ref values)) { }
-                            else if (SetPropertyIndex(7,  property7,  ref reader, ref values)) { }
-                            else if (SetPropertyIndex(8,  property8,  ref reader, ref values)) { }
-                            else if (SetPropertyIndex(9,  property9,  ref reader, ref values)) { }
-                            else if (SetPropertyIndex(10, property10, ref reader, ref values)) { }
-                            else if (SetPropertyIndex(11, property11, ref reader, ref values)) { }
-                            else if (SetPropertyIndex(12, property12, ref reader, ref values)) { }
-                            else if (SetPropertyIndex(13, property13, ref reader, ref values)) { }
-                            else if (SetPropertyIndex(14, property14, ref reader, ref values)) { }
-                            else if (SetPropertyIndex(15, property15, ref reader, ref values)) { }
-                            else if (SetPropertyIndex(16, property16, ref reader, ref values)) { }
+                                 if (TrySetPropertyIndex(1,  property1,  ref reader, ref values)) { }
+                            else if (TrySetPropertyIndex(2,  property2,  ref reader, ref values)) { }
+                            else if (TrySetPropertyIndex(3,  property3,  ref reader, ref values)) { }
+                            else if (TrySetPropertyIndex(4,  property4,  ref reader, ref values)) { }
+                            else if (TrySetPropertyIndex(5,  property5,  ref reader, ref values)) { }
+                            else if (TrySetPropertyIndex(6,  property6,  ref reader, ref values)) { }
+                            else if (TrySetPropertyIndex(7,  property7,  ref reader, ref values)) { }
+                            else if (TrySetPropertyIndex(8,  property8,  ref reader, ref values)) { }
+                            else if (TrySetPropertyIndex(9,  property9,  ref reader, ref values)) { }
+                            else if (TrySetPropertyIndex(10, property10, ref reader, ref values)) { }
+                            else if (TrySetPropertyIndex(11, property11, ref reader, ref values)) { }
+                            else if (TrySetPropertyIndex(12, property12, ref reader, ref values)) { }
+                            else if (TrySetPropertyIndex(13, property13, ref reader, ref values)) { }
+                            else if (TrySetPropertyIndex(14, property14, ref reader, ref values)) { }
+                            else if (TrySetPropertyIndex(15, property15, ref reader, ref values)) { }
+                            else if (TrySetPropertyIndex(16, property16, ref reader, ref values)) { }
 
                             if (!reader.Read())
                                 return reader.Suspend((sm, values));

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -625,9 +625,6 @@ public static partial class JsonReader
                                 || TrySetPropertyIndex(15, property15, ref reader, ref currentPropertyIndex)
                                 || TrySetPropertyIndex(16, property16, ref reader, ref currentPropertyIndex);
 
-                            if (!reader.Read())
-                                return reader.Suspend((sm, state));
-
                             sm.OnPropertyNameRead();
 
                             break;

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -533,26 +533,26 @@ public static partial class JsonReader
                NonProperty.Instance,
                (v, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _) => v);
 
-    struct Values<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>
+    struct ObjectValueState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>
     {
-        public (bool, T1) P1;
-        public (bool, T2) P2;
-        public (bool, T3) P3;
-        public (bool, T4) P4;
-        public (bool, T5) P5;
-        public (bool, T6) P6;
-        public (bool, T7) P7;
-        public (bool, T8) P8;
-        public (bool, T9) P9;
-        public (bool, T10) P10;
-        public (bool, T11) P11;
-        public (bool, T12) P12;
-        public (bool, T13) P13;
-        public (bool, T14) P14;
-        public (bool, T15) P15;
-        public (bool, T16) P16;
+        public (bool, T1) V1;
+        public (bool, T2) V2;
+        public (bool, T3) V3;
+        public (bool, T4) V4;
+        public (bool, T5) V5;
+        public (bool, T6) V6;
+        public (bool, T7) V7;
+        public (bool, T8) V8;
+        public (bool, T9) V9;
+        public (bool, T10) V10;
+        public (bool, T11) V11;
+        public (bool, T12) V12;
+        public (bool, T13) V13;
+        public (bool, T14) V14;
+        public (bool, T15) V15;
+        public (bool, T16) V16;
 
-        public int? NextPropertyIndex;
+        public int? CurrentPropertyIndex;
     };
 
     /// <remarks>
@@ -573,13 +573,13 @@ public static partial class JsonReader
         Create((ref Utf8JsonReader reader) =>
         {
             var (sm, values) =
-                reader.IsResuming && ((ObjectReadStateMachine, Values<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>))reader.Pop() is var ps
+                reader.IsResuming && ((ObjectReadStateMachine, ObjectValueState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>))reader.Pop() is var ps
                     ? ps
                     : default;
 
             return Read(ref reader, sm, ref values);
 
-            JsonReadResult<TResult> Read(ref Utf8JsonReader reader, ObjectReadStateMachine sm, ref Values<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> values)
+            JsonReadResult<TResult> Read(ref Utf8JsonReader reader, ObjectReadStateMachine sm, ref ObjectValueState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> values)
             {
                 while (true)
                 {
@@ -598,29 +598,29 @@ public static partial class JsonReader
                                     v = (true, property.DefaultValue);
                             }
 
-                            DefaultUnassigned(property1, ref values.P1);
-                            DefaultUnassigned(property2, ref values.P2);
-                            DefaultUnassigned(property3, ref values.P3);
-                            DefaultUnassigned(property4, ref values.P4);
-                            DefaultUnassigned(property5, ref values.P5);
-                            DefaultUnassigned(property6, ref values.P6);
-                            DefaultUnassigned(property7, ref values.P7);
-                            DefaultUnassigned(property8, ref values.P8);
-                            DefaultUnassigned(property9, ref values.P9);
-                            DefaultUnassigned(property10, ref values.P10);
-                            DefaultUnassigned(property11, ref values.P11);
-                            DefaultUnassigned(property12, ref values.P12);
-                            DefaultUnassigned(property13, ref values.P13);
-                            DefaultUnassigned(property14, ref values.P14);
-                            DefaultUnassigned(property15, ref values.P15);
-                            DefaultUnassigned(property16, ref values.P16);
+                            DefaultUnassigned(property1,  ref values.V1);
+                            DefaultUnassigned(property2,  ref values.V2);
+                            DefaultUnassigned(property3,  ref values.V3);
+                            DefaultUnassigned(property4,  ref values.V4);
+                            DefaultUnassigned(property5,  ref values.V5);
+                            DefaultUnassigned(property6,  ref values.V6);
+                            DefaultUnassigned(property7,  ref values.V7);
+                            DefaultUnassigned(property8,  ref values.V8);
+                            DefaultUnassigned(property9,  ref values.V9);
+                            DefaultUnassigned(property10, ref values.V10);
+                            DefaultUnassigned(property11, ref values.V11);
+                            DefaultUnassigned(property12, ref values.V12);
+                            DefaultUnassigned(property13, ref values.V13);
+                            DefaultUnassigned(property14, ref values.V14);
+                            DefaultUnassigned(property15, ref values.V15);
+                            DefaultUnassigned(property16, ref values.V16);
 
-                            return (values.P1, values.P2, values.P3,
-                                    values.P4, values.P5, values.P6,
-                                    values.P7, values.P8, values.P9,
-                                    values.P10, values.P11, values.P12,
-                                    values.P13, values.P14, values.P15,
-                                    values.P16) is ((true, var v1), (true, var v2), (true, var v3),
+                            return (values.V1, values.V2, values.V3,
+                                    values.V4, values.V5, values.V6,
+                                    values.V7, values.V8, values.V9,
+                                    values.V10, values.V11, values.V12,
+                                    values.V13, values.V14, values.V15,
+                                    values.V16) is ((true, var v1), (true, var v2), (true, var v3),
                                                     (true, var v4), (true, var v5), (true, var v6),
                                                     (true, var v7), (true, var v8), (true, var v9),
                                                     (true, var v10), (true, var v11), (true, var v12),
@@ -633,12 +633,12 @@ public static partial class JsonReader
                             static bool TrySetPropertyIndex<TValue>(int index,
                                                                     IJsonProperty<TValue, JsonReadResult<TValue>> property,
                                                                     ref Utf8JsonReader reader,
-                                                                    ref Values<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> values)
+                                                                    ref ObjectValueState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> values)
                             {
                                 if (!property.IsMatch(ref reader))
                                     return false;
 
-                                values.NextPropertyIndex = index;
+                                values.CurrentPropertyIndex = index;
                                 return true;
                             }
 
@@ -677,7 +677,7 @@ public static partial class JsonReader
                                                                                       ref Utf8JsonReader reader,
                                                                                       ref (bool, TValue) value,
                                                                                       ref ObjectReadStateMachine sm,
-                                                                                      ref Values<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> values)
+                                                                                      ref ObjectValueState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> values)
                             {
                                 switch (property.Reader.TryRead(ref reader))
                                 {
@@ -691,26 +691,26 @@ public static partial class JsonReader
                                 }
                             }
 
-                            if (values.NextPropertyIndex is { } nextPropertyIndex)
+                            if (values.CurrentPropertyIndex is { } nextPropertyIndex)
                             {
                                 var error = nextPropertyIndex switch
                                 {
-                                    1  => ReadPropertyValue(property1,  ref reader, ref values.P1,  ref sm, ref values),
-                                    2  => ReadPropertyValue(property2,  ref reader, ref values.P2,  ref sm, ref values),
-                                    3  => ReadPropertyValue(property3,  ref reader, ref values.P3,  ref sm, ref values),
-                                    4  => ReadPropertyValue(property4,  ref reader, ref values.P4,  ref sm, ref values),
-                                    5  => ReadPropertyValue(property5,  ref reader, ref values.P5,  ref sm, ref values),
-                                    6  => ReadPropertyValue(property6,  ref reader, ref values.P6,  ref sm, ref values),
-                                    7  => ReadPropertyValue(property7,  ref reader, ref values.P7,  ref sm, ref values),
-                                    8  => ReadPropertyValue(property8,  ref reader, ref values.P8,  ref sm, ref values),
-                                    9  => ReadPropertyValue(property9,  ref reader, ref values.P9,  ref sm, ref values),
-                                    10 => ReadPropertyValue(property10, ref reader, ref values.P10, ref sm, ref values),
-                                    11 => ReadPropertyValue(property11, ref reader, ref values.P11, ref sm, ref values),
-                                    12 => ReadPropertyValue(property12, ref reader, ref values.P12, ref sm, ref values),
-                                    13 => ReadPropertyValue(property13, ref reader, ref values.P13, ref sm, ref values),
-                                    14 => ReadPropertyValue(property14, ref reader, ref values.P14, ref sm, ref values),
-                                    15 => ReadPropertyValue(property15, ref reader, ref values.P15, ref sm, ref values),
-                                    16 => ReadPropertyValue(property16, ref reader, ref values.P16, ref sm, ref values),
+                                    1  => ReadPropertyValue(property1,  ref reader, ref values.V1,  ref sm, ref values),
+                                    2  => ReadPropertyValue(property2,  ref reader, ref values.V2,  ref sm, ref values),
+                                    3  => ReadPropertyValue(property3,  ref reader, ref values.V3,  ref sm, ref values),
+                                    4  => ReadPropertyValue(property4,  ref reader, ref values.V4,  ref sm, ref values),
+                                    5  => ReadPropertyValue(property5,  ref reader, ref values.V5,  ref sm, ref values),
+                                    6  => ReadPropertyValue(property6,  ref reader, ref values.V6,  ref sm, ref values),
+                                    7  => ReadPropertyValue(property7,  ref reader, ref values.V7,  ref sm, ref values),
+                                    8  => ReadPropertyValue(property8,  ref reader, ref values.V8,  ref sm, ref values),
+                                    9  => ReadPropertyValue(property9,  ref reader, ref values.V9,  ref sm, ref values),
+                                    10 => ReadPropertyValue(property10, ref reader, ref values.V10, ref sm, ref values),
+                                    11 => ReadPropertyValue(property11, ref reader, ref values.V11, ref sm, ref values),
+                                    12 => ReadPropertyValue(property12, ref reader, ref values.V12, ref sm, ref values),
+                                    13 => ReadPropertyValue(property13, ref reader, ref values.V13, ref sm, ref values),
+                                    14 => ReadPropertyValue(property14, ref reader, ref values.V14, ref sm, ref values),
+                                    15 => ReadPropertyValue(property15, ref reader, ref values.V15, ref sm, ref values),
+                                    16 => ReadPropertyValue(property16, ref reader, ref values.V16, ref sm, ref values),
                                     _ => throw new InvalidOperationException()
                                 };
 
@@ -726,7 +726,7 @@ public static partial class JsonReader
                             }
 
                             sm.OnPropertyValueRead();
-                            values.NextPropertyIndex = null;
+                            values.CurrentPropertyIndex = null;
 
                             break;
                     }

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -631,10 +631,10 @@ public static partial class JsonReader
                                  : Error("Invalid JSON object.");
 
                         case ObjectReadStateMachine.ReadResult.PropertyName:
-                            static bool TrySetPropertyIndex<TValue>(int index,
-                                                                    IJsonProperty<TValue, JsonReadResult<TValue>> property,
-                                                                    ref Utf8JsonReader reader,
-                                                                    ref ObjectReadState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> state)
+                            static bool TrySetPropertyIndex<T>(int index,
+                                                               IJsonProperty<T, JsonReadResult<T>> property,
+                                                               ref Utf8JsonReader reader,
+                                                               ref ObjectReadState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> state)
                             {
                                 if (!property.IsMatch(ref reader))
                                     return false;
@@ -668,11 +668,11 @@ public static partial class JsonReader
                             break;
 
                         case ObjectReadStateMachine.ReadResult.PropertyValue:
-                            static JsonReadResult<TResult>? ReadPropertyValue<TValue>(IJsonProperty<TValue, JsonReadResult<TValue>> property,
-                                                                                      ref Utf8JsonReader reader,
-                                                                                      ref (bool, TValue) value,
-                                                                                      ref ObjectReadStateMachine sm,
-                                                                                      ref ObjectReadState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> state)
+                            static JsonReadResult<TResult>? ReadPropertyValue<T>(IJsonProperty<T, JsonReadResult<T>> property,
+                                                                                 ref Utf8JsonReader reader,
+                                                                                 ref (bool, T) value,
+                                                                                 ref ObjectReadStateMachine sm,
+                                                                                 ref ObjectReadState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> state)
                             {
                                 switch (property.Reader.TryRead(ref reader))
                                 {

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -688,7 +688,7 @@ public static partial class JsonReader
 
                             if (values.CurrentPropertyIndex is { } nextPropertyIndex)
                             {
-                                var error = nextPropertyIndex switch
+                                var result = nextPropertyIndex switch
                                 {
                                     1  => ReadPropertyValue(property1,  ref reader, ref values.V1,  ref sm, ref values),
                                     2  => ReadPropertyValue(property2,  ref reader, ref values.V2,  ref sm, ref values),
@@ -709,7 +709,7 @@ public static partial class JsonReader
                                     var i => throw new SwitchExpressionException(i)
                                 };
 
-                                if (error is { } someResult)
+                                if (result is { } someResult)
                                     return someResult;
                             }
                             else

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -577,9 +577,9 @@ public static partial class JsonReader
                     ? ps
                     : default;
 
-            return Read(ref reader, sm, values);
+            return Read(ref reader, sm, ref values);
 
-            JsonReadResult<TResult> Read(ref Utf8JsonReader reader, ObjectReadStateMachine sm, Values<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> values)
+            JsonReadResult<TResult> Read(ref Utf8JsonReader reader, ObjectReadStateMachine sm, ref Values<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> values)
             {
                 while (true)
                 {

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -590,10 +590,10 @@ public static partial class JsonReader
                         }
                         case ObjectReadStateMachine.ReadResult.PropertyName:
                         {
-                            static bool TrySetPropertyIndex<TValue>(int index,
-                                                                    IJsonProperty<TValue, JsonReadResult<TValue>> property,
-                                                                    ref Utf8JsonReader reader,
-                                                                    ref int? currentIndex)
+                            static bool TrySetPropertyIndex<T>(int index,
+                                                               IJsonProperty<T, JsonReadResult<T>> property,
+                                                               ref Utf8JsonReader reader,
+                                                               ref int? currentIndex)
                             {
                                 if (!property.IsMatch(ref reader))
                                     return false;

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -533,7 +533,7 @@ public static partial class JsonReader
                NonProperty.Instance,
                (v, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _) => v);
 
-    struct ObjectValueState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>
+    struct ObjectReadState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>
     {
         public (bool, T1) V1;
         public (bool, T2) V2;
@@ -573,14 +573,14 @@ public static partial class JsonReader
         Create((ref Utf8JsonReader reader) =>
         {
             var (sm, values) =
-                reader.IsResuming && ((ObjectReadStateMachine, ObjectValueState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>))reader.Pop() is var ps
+                reader.IsResuming && ((ObjectReadStateMachine, ObjectReadState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>))reader.Pop() is var ps
                     ? ps
                     : default;
 
             return Read(ref reader, sm, ref values);
 
             JsonReadResult<TResult> Read(ref Utf8JsonReader reader, ObjectReadStateMachine sm,
-                                         ref ObjectValueState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> values)
+                                         ref ObjectReadState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> values)
             {
                 while (true)
                 {
@@ -634,7 +634,7 @@ public static partial class JsonReader
                             static bool TrySetPropertyIndex<TValue>(int index,
                                                                     IJsonProperty<TValue, JsonReadResult<TValue>> property,
                                                                     ref Utf8JsonReader reader,
-                                                                    ref ObjectValueState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> values)
+                                                                    ref ObjectReadState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> values)
                             {
                                 if (!property.IsMatch(ref reader))
                                     return false;
@@ -672,7 +672,7 @@ public static partial class JsonReader
                                                                                       ref Utf8JsonReader reader,
                                                                                       ref (bool, TValue) value,
                                                                                       ref ObjectReadStateMachine sm,
-                                                                                      ref ObjectValueState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> values)
+                                                                                      ref ObjectReadState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> values)
                             {
                                 switch (property.Reader.TryRead(ref reader))
                                 {

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -572,15 +572,15 @@ public static partial class JsonReader
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> projector) =>
         Create((ref Utf8JsonReader reader) =>
         {
-            var (sm, values) =
+            var (sm, state) =
                 reader.IsResuming && ((ObjectReadStateMachine, ObjectReadState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>))reader.Pop() is var ps
                     ? ps
                     : default;
 
-            return Read(ref reader, sm, ref values);
+            return Read(ref reader, sm, ref state);
 
             JsonReadResult<TResult> Read(ref Utf8JsonReader reader, ObjectReadStateMachine sm,
-                                         ref ObjectReadState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> values)
+                                         ref ObjectReadState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> state)
             {
                 while (true)
                 {
@@ -590,7 +590,7 @@ public static partial class JsonReader
                             return Error("Invalid JSON value where a JSON object was expected.");
 
                         case ObjectReadStateMachine.ReadResult.Incomplete:
-                            return reader.Suspend((sm, values));
+                            return reader.Suspend((sm, state));
 
                         case ObjectReadStateMachine.ReadResult.Done:
                             static void DefaultUnassigned<T>(IJsonProperty<T, JsonReadResult<T>> property, ref (bool, T) v)
@@ -599,29 +599,29 @@ public static partial class JsonReader
                                     v = (true, property.DefaultValue);
                             }
 
-                            DefaultUnassigned(property1,  ref values.V1);
-                            DefaultUnassigned(property2,  ref values.V2);
-                            DefaultUnassigned(property3,  ref values.V3);
-                            DefaultUnassigned(property4,  ref values.V4);
-                            DefaultUnassigned(property5,  ref values.V5);
-                            DefaultUnassigned(property6,  ref values.V6);
-                            DefaultUnassigned(property7,  ref values.V7);
-                            DefaultUnassigned(property8,  ref values.V8);
-                            DefaultUnassigned(property9,  ref values.V9);
-                            DefaultUnassigned(property10, ref values.V10);
-                            DefaultUnassigned(property11, ref values.V11);
-                            DefaultUnassigned(property12, ref values.V12);
-                            DefaultUnassigned(property13, ref values.V13);
-                            DefaultUnassigned(property14, ref values.V14);
-                            DefaultUnassigned(property15, ref values.V15);
-                            DefaultUnassigned(property16, ref values.V16);
+                            DefaultUnassigned(property1,  ref state.V1);
+                            DefaultUnassigned(property2,  ref state.V2);
+                            DefaultUnassigned(property3,  ref state.V3);
+                            DefaultUnassigned(property4,  ref state.V4);
+                            DefaultUnassigned(property5,  ref state.V5);
+                            DefaultUnassigned(property6,  ref state.V6);
+                            DefaultUnassigned(property7,  ref state.V7);
+                            DefaultUnassigned(property8,  ref state.V8);
+                            DefaultUnassigned(property9,  ref state.V9);
+                            DefaultUnassigned(property10, ref state.V10);
+                            DefaultUnassigned(property11, ref state.V11);
+                            DefaultUnassigned(property12, ref state.V12);
+                            DefaultUnassigned(property13, ref state.V13);
+                            DefaultUnassigned(property14, ref state.V14);
+                            DefaultUnassigned(property15, ref state.V15);
+                            DefaultUnassigned(property16, ref state.V16);
 
-                            return (values.V1, values.V2, values.V3,
-                                    values.V4, values.V5, values.V6,
-                                    values.V7, values.V8, values.V9,
-                                    values.V10, values.V11, values.V12,
-                                    values.V13, values.V14, values.V15,
-                                    values.V16) is ((true, var v1), (true, var v2), (true, var v3),
+                            return (state.V1, state.V2, state.V3,
+                                    state.V4, state.V5, state.V6,
+                                    state.V7, state.V8, state.V9,
+                                    state.V10, state.V11, state.V12,
+                                    state.V13, state.V14, state.V15,
+                                    state.V16) is ((true, var v1), (true, var v2), (true, var v3),
                                                     (true, var v4), (true, var v5), (true, var v6),
                                                     (true, var v7), (true, var v8), (true, var v9),
                                                     (true, var v10), (true, var v11), (true, var v12),
@@ -634,34 +634,34 @@ public static partial class JsonReader
                             static bool TrySetPropertyIndex<TValue>(int index,
                                                                     IJsonProperty<TValue, JsonReadResult<TValue>> property,
                                                                     ref Utf8JsonReader reader,
-                                                                    ref ObjectReadState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> values)
+                                                                    ref ObjectReadState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> state)
                             {
                                 if (!property.IsMatch(ref reader))
                                     return false;
 
-                                values.CurrentPropertyIndex = index;
+                                state.CurrentPropertyIndex = index;
                                 return true;
                             }
 
-                            _ =    TrySetPropertyIndex(1,  property1,  ref reader, ref values)
-                                || TrySetPropertyIndex(2,  property2,  ref reader, ref values)
-                                || TrySetPropertyIndex(3,  property3,  ref reader, ref values)
-                                || TrySetPropertyIndex(4,  property4,  ref reader, ref values)
-                                || TrySetPropertyIndex(5,  property5,  ref reader, ref values)
-                                || TrySetPropertyIndex(6,  property6,  ref reader, ref values)
-                                || TrySetPropertyIndex(7,  property7,  ref reader, ref values)
-                                || TrySetPropertyIndex(8,  property8,  ref reader, ref values)
-                                || TrySetPropertyIndex(9,  property9,  ref reader, ref values)
-                                || TrySetPropertyIndex(10, property10, ref reader, ref values)
-                                || TrySetPropertyIndex(11, property11, ref reader, ref values)
-                                || TrySetPropertyIndex(12, property12, ref reader, ref values)
-                                || TrySetPropertyIndex(13, property13, ref reader, ref values)
-                                || TrySetPropertyIndex(14, property14, ref reader, ref values)
-                                || TrySetPropertyIndex(15, property15, ref reader, ref values)
-                                || TrySetPropertyIndex(16, property16, ref reader, ref values);
+                            _ =    TrySetPropertyIndex(1,  property1,  ref reader, ref state)
+                                || TrySetPropertyIndex(2,  property2,  ref reader, ref state)
+                                || TrySetPropertyIndex(3,  property3,  ref reader, ref state)
+                                || TrySetPropertyIndex(4,  property4,  ref reader, ref state)
+                                || TrySetPropertyIndex(5,  property5,  ref reader, ref state)
+                                || TrySetPropertyIndex(6,  property6,  ref reader, ref state)
+                                || TrySetPropertyIndex(7,  property7,  ref reader, ref state)
+                                || TrySetPropertyIndex(8,  property8,  ref reader, ref state)
+                                || TrySetPropertyIndex(9,  property9,  ref reader, ref state)
+                                || TrySetPropertyIndex(10, property10, ref reader, ref state)
+                                || TrySetPropertyIndex(11, property11, ref reader, ref state)
+                                || TrySetPropertyIndex(12, property12, ref reader, ref state)
+                                || TrySetPropertyIndex(13, property13, ref reader, ref state)
+                                || TrySetPropertyIndex(14, property14, ref reader, ref state)
+                                || TrySetPropertyIndex(15, property15, ref reader, ref state)
+                                || TrySetPropertyIndex(16, property16, ref reader, ref state);
 
                             if (!reader.Read())
-                                return reader.Suspend((sm, values));
+                                return reader.Suspend((sm, state));
 
                             sm.OnPropertyNameRead();
 
@@ -672,12 +672,12 @@ public static partial class JsonReader
                                                                                       ref Utf8JsonReader reader,
                                                                                       ref (bool, TValue) value,
                                                                                       ref ObjectReadStateMachine sm,
-                                                                                      ref ObjectReadState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> values)
+                                                                                      ref ObjectReadState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> state)
                             {
                                 switch (property.Reader.TryRead(ref reader))
                                 {
                                     case { Incomplete: true }:
-                                        return reader.Suspend((sm, values));
+                                        return reader.Suspend((sm, state));
                                     case { Error: { } err }:
                                         return new JsonReadError(err);
                                     case { Value: var val }:
@@ -686,26 +686,26 @@ public static partial class JsonReader
                                 }
                             }
 
-                            if (values.CurrentPropertyIndex is { } nextPropertyIndex)
+                            if (state.CurrentPropertyIndex is { } nextPropertyIndex)
                             {
                                 var result = nextPropertyIndex switch
                                 {
-                                    1  => ReadPropertyValue(property1,  ref reader, ref values.V1,  ref sm, ref values),
-                                    2  => ReadPropertyValue(property2,  ref reader, ref values.V2,  ref sm, ref values),
-                                    3  => ReadPropertyValue(property3,  ref reader, ref values.V3,  ref sm, ref values),
-                                    4  => ReadPropertyValue(property4,  ref reader, ref values.V4,  ref sm, ref values),
-                                    5  => ReadPropertyValue(property5,  ref reader, ref values.V5,  ref sm, ref values),
-                                    6  => ReadPropertyValue(property6,  ref reader, ref values.V6,  ref sm, ref values),
-                                    7  => ReadPropertyValue(property7,  ref reader, ref values.V7,  ref sm, ref values),
-                                    8  => ReadPropertyValue(property8,  ref reader, ref values.V8,  ref sm, ref values),
-                                    9  => ReadPropertyValue(property9,  ref reader, ref values.V9,  ref sm, ref values),
-                                    10 => ReadPropertyValue(property10, ref reader, ref values.V10, ref sm, ref values),
-                                    11 => ReadPropertyValue(property11, ref reader, ref values.V11, ref sm, ref values),
-                                    12 => ReadPropertyValue(property12, ref reader, ref values.V12, ref sm, ref values),
-                                    13 => ReadPropertyValue(property13, ref reader, ref values.V13, ref sm, ref values),
-                                    14 => ReadPropertyValue(property14, ref reader, ref values.V14, ref sm, ref values),
-                                    15 => ReadPropertyValue(property15, ref reader, ref values.V15, ref sm, ref values),
-                                    16 => ReadPropertyValue(property16, ref reader, ref values.V16, ref sm, ref values),
+                                    1  => ReadPropertyValue(property1,  ref reader, ref state.V1,  ref sm, ref state),
+                                    2  => ReadPropertyValue(property2,  ref reader, ref state.V2,  ref sm, ref state),
+                                    3  => ReadPropertyValue(property3,  ref reader, ref state.V3,  ref sm, ref state),
+                                    4  => ReadPropertyValue(property4,  ref reader, ref state.V4,  ref sm, ref state),
+                                    5  => ReadPropertyValue(property5,  ref reader, ref state.V5,  ref sm, ref state),
+                                    6  => ReadPropertyValue(property6,  ref reader, ref state.V6,  ref sm, ref state),
+                                    7  => ReadPropertyValue(property7,  ref reader, ref state.V7,  ref sm, ref state),
+                                    8  => ReadPropertyValue(property8,  ref reader, ref state.V8,  ref sm, ref state),
+                                    9  => ReadPropertyValue(property9,  ref reader, ref state.V9,  ref sm, ref state),
+                                    10 => ReadPropertyValue(property10, ref reader, ref state.V10, ref sm, ref state),
+                                    11 => ReadPropertyValue(property11, ref reader, ref state.V11, ref sm, ref state),
+                                    12 => ReadPropertyValue(property12, ref reader, ref state.V12, ref sm, ref state),
+                                    13 => ReadPropertyValue(property13, ref reader, ref state.V13, ref sm, ref state),
+                                    14 => ReadPropertyValue(property14, ref reader, ref state.V14, ref sm, ref state),
+                                    15 => ReadPropertyValue(property15, ref reader, ref state.V15, ref sm, ref state),
+                                    16 => ReadPropertyValue(property16, ref reader, ref state.V16, ref sm, ref state),
                                     var i => throw new SwitchExpressionException(i)
                                 };
 
@@ -717,11 +717,11 @@ public static partial class JsonReader
                                 if (reader.IsFinalBlock)
                                     reader.Skip();
                                 else if (!reader.TrySkip())
-                                    return reader.Suspend((sm, values));
+                                    return reader.Suspend((sm, state));
                             }
 
                             sm.OnPropertyValueRead();
-                            values.CurrentPropertyIndex = null;
+                            state.CurrentPropertyIndex = null;
 
                             break;
                     }

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -581,11 +581,13 @@ public static partial class JsonReader
                     switch (sm.Read(ref reader))
                     {
                         case ObjectReadStateMachine.ReadResult.Error:
+                        {
                             return Error("Invalid JSON value where a JSON object was expected.");
-
+                        }
                         case ObjectReadStateMachine.ReadResult.Incomplete:
+                        {
                             return reader.Suspend((sm, state));
-
+                        }
                         case ObjectReadStateMachine.ReadResult.PropertyName:
                         {
                             static bool TrySetPropertyIndex<TValue>(int index,
@@ -623,7 +625,6 @@ public static partial class JsonReader
 
                             break;
                         }
-
                         case ObjectReadStateMachine.ReadResult.PropertyValue:
                         {
                             static JsonReadResult<TResult>? ReadPropertyValue<T>(ref Utf8JsonReader reader,
@@ -683,7 +684,6 @@ public static partial class JsonReader
 
                             break;
                         }
-
                         case ObjectReadStateMachine.ReadResult.Done:
                         {
                             static void DefaultUnassigned<T>(IJsonProperty<T, JsonReadResult<T>> property, ref (bool, T) v)

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -533,6 +533,28 @@ public static partial class JsonReader
                NonProperty.Instance,
                (v, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _) => v);
 
+    struct Values<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>
+    {
+        public (bool, T1) P1;
+        public (bool, T2) P2;
+        public (bool, T3) P3;
+        public (bool, T4) P4;
+        public (bool, T5) P5;
+        public (bool, T6) P6;
+        public (bool, T7) P7;
+        public (bool, T8) P8;
+        public (bool, T9) P9;
+        public (bool, T10) P10;
+        public (bool, T11) P11;
+        public (bool, T12) P12;
+        public (bool, T13) P13;
+        public (bool, T14) P14;
+        public (bool, T15) P15;
+        public (bool, T16) P16;
+
+        public int? NextPropertyIndex;
+    };
+
     /// <remarks>
     /// Properties without a default value that are missing from the read JSON object will cause
     /// the reader to return an error result.
@@ -548,127 +570,166 @@ public static partial class JsonReader
             IJsonProperty<T13, JsonReadResult<T13>> property13, IJsonProperty<T14, JsonReadResult<T14>> property14,
             IJsonProperty<T15, JsonReadResult<T15>> property15, IJsonProperty<T16, JsonReadResult<T16>> property16,
             Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> projector) =>
-        CreatePure((ref Utf8JsonReader reader) =>
+        Create((ref Utf8JsonReader reader) =>
         {
-            if (reader.TokenType is JsonTokenType.None && !reader.Read())
-                throw PartialJsonNotSupportedException();
+            var (sm, values) =
+                reader.IsResuming && ((ObjectReadStateMachine, Values<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>))reader.Pop() is var ps
+                    ? ps
+                    : default;
 
-            var tokenType = reader.TokenType;
-            if (tokenType is not JsonTokenType.StartObject)
-                return Error("Invalid JSON value where a JSON object was expected.");
+            return Read(ref reader, sm, values);
 
-            (bool, T1) value1 = default;
-            (bool, T2) value2 = default;
-            (bool, T3) value3 = default;
-            (bool, T4) value4 = default;
-            (bool, T5) value5 = default;
-            (bool, T6) value6 = default;
-            (bool, T7) value7 = default;
-            (bool, T8) value8 = default;
-            (bool, T9) value9 = default;
-            (bool, T10) value10 = default;
-            (bool, T11) value11 = default;
-            (bool, T12) value12 = default;
-            (bool, T13) value13 = default;
-            (bool, T14) value14 = default;
-            (bool, T15) value15 = default;
-            (bool, T16) value16 = default;
-
-            while (true)
+            JsonReadResult<TResult> Read(ref Utf8JsonReader reader, ObjectReadStateMachine sm, Values<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> values)
             {
-                string? error = null;
-
-                if (!reader.TryReadToken(out tokenType))
-                    throw PartialJsonNotSupportedException();
-
-                if (tokenType is JsonTokenType.EndObject)
-                    break;
-
-                Debug.Assert(reader.TokenType is JsonTokenType.PropertyName);
-
-                if (ReadPropertyValue(property1, ref reader, ref value1, ref error)) continue; if (error is not null) return Error(error);
-                if (ReadPropertyValue(property2, ref reader, ref value2, ref error)) continue; if (error is not null) return Error(error);
-                if (ReadPropertyValue(property3, ref reader, ref value3, ref error)) continue; if (error is not null) return Error(error);
-                if (ReadPropertyValue(property4, ref reader, ref value4, ref error)) continue; if (error is not null) return Error(error);
-                if (ReadPropertyValue(property5, ref reader, ref value5, ref error)) continue; if (error is not null) return Error(error);
-                if (ReadPropertyValue(property6, ref reader, ref value6, ref error)) continue; if (error is not null) return Error(error);
-                if (ReadPropertyValue(property7, ref reader, ref value7, ref error)) continue; if (error is not null) return Error(error);
-                if (ReadPropertyValue(property8, ref reader, ref value8, ref error)) continue; if (error is not null) return Error(error);
-                if (ReadPropertyValue(property9, ref reader, ref value9, ref error)) continue; if (error is not null) return Error(error);
-                if (ReadPropertyValue(property10, ref reader, ref value10, ref error)) continue; if (error is not null) return Error(error);
-                if (ReadPropertyValue(property11, ref reader, ref value11, ref error)) continue; if (error is not null) return Error(error);
-                if (ReadPropertyValue(property12, ref reader, ref value12, ref error)) continue; if (error is not null) return Error(error);
-                if (ReadPropertyValue(property13, ref reader, ref value13, ref error)) continue; if (error is not null) return Error(error);
-                if (ReadPropertyValue(property14, ref reader, ref value14, ref error)) continue; if (error is not null) return Error(error);
-                if (ReadPropertyValue(property15, ref reader, ref value15, ref error)) continue; if (error is not null) return Error(error);
-                if (ReadPropertyValue(property16, ref reader, ref value16, ref error)) continue; if (error is not null) return Error(error);
-
-                if (reader.IsFinalBlock)
-                    reader.Skip();
-                else if (!reader.TrySkip())
-                    throw PartialJsonNotSupportedException();
-
-                static bool ReadPropertyValue<TValue>(IJsonProperty<TValue, JsonReadResult<TValue>> property,
-                                                      ref Utf8JsonReader reader,
-                                                      ref (bool, TValue) value,
-                                                      ref string? error)
+                while (true)
                 {
-                    if (!property.IsMatch(ref reader))
-                        return false;
-
-                    if (!reader.Read())
-                        throw PartialJsonNotSupportedException();
-
-                    switch (property.Reader.TryRead(ref reader))
+                    switch (sm.Read(ref reader))
                     {
-                        case { Incomplete: true }:
-                            throw PartialJsonNotSupportedException();
-                        case { Error: { } err }:
-                            error = err;
-                            return false;
-                        case { Value: var val }:
-                            value = (true, val);
-                            return true;
+                        case ObjectReadStateMachine.ReadResult.Error:
+                            return Error("Invalid JSON value where a JSON object was expected.");
+
+                        case ObjectReadStateMachine.ReadResult.Incomplete:
+                            return reader.Suspend((sm, values));
+
+                        case ObjectReadStateMachine.ReadResult.Done:
+                            static void DefaultUnassigned<T>(IJsonProperty<T, JsonReadResult<T>> property, ref (bool, T) v)
+                            {
+                                if (v is (false, _) && property.HasDefaultValue)
+                                    v = (true, property.DefaultValue);
+                            }
+
+                            DefaultUnassigned(property1, ref values.P1);
+                            DefaultUnassigned(property2, ref values.P2);
+                            DefaultUnassigned(property3, ref values.P3);
+                            DefaultUnassigned(property4, ref values.P4);
+                            DefaultUnassigned(property5, ref values.P5);
+                            DefaultUnassigned(property6, ref values.P6);
+                            DefaultUnassigned(property7, ref values.P7);
+                            DefaultUnassigned(property8, ref values.P8);
+                            DefaultUnassigned(property9, ref values.P9);
+                            DefaultUnassigned(property10, ref values.P10);
+                            DefaultUnassigned(property11, ref values.P11);
+                            DefaultUnassigned(property12, ref values.P12);
+                            DefaultUnassigned(property13, ref values.P13);
+                            DefaultUnassigned(property14, ref values.P14);
+                            DefaultUnassigned(property15, ref values.P15);
+                            DefaultUnassigned(property16, ref values.P16);
+
+                            return (values.P1, values.P2, values.P3,
+                                    values.P4, values.P5, values.P6,
+                                    values.P7, values.P8, values.P9,
+                                    values.P10, values.P11, values.P12,
+                                    values.P13, values.P14, values.P15,
+                                    values.P16) is ((true, var v1), (true, var v2), (true, var v3),
+                                                    (true, var v4), (true, var v5), (true, var v6),
+                                                    (true, var v7), (true, var v8), (true, var v9),
+                                                    (true, var v10), (true, var v11), (true, var v12),
+                                                    (true, var v13), (true, var v14), (true, var v15),
+                                                    (true, var v16))
+                                 ? Value(projector(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16))
+                                 : Error("Invalid JSON object.");
+
+                        case ObjectReadStateMachine.ReadResult.PropertyName:
+                            static bool SetPropertyIndex<TValue>(int index, IJsonProperty<TValue, JsonReadResult<TValue>> property, ref Utf8JsonReader reader, ref Values<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> values)
+                            {
+                                if (!property.IsMatch(ref reader))
+                                    return false;
+
+                                values.NextPropertyIndex = index;
+                                return true;
+                            }
+
+                            if (sm.CurrentPropertyLoopCount is 0)
+                            {
+                                var read = reader.Read();
+                                Debug.Assert(read);
+                            }
+
+                            if (SetPropertyIndex(1, property1, ref reader, ref values)) { }
+                            else if (SetPropertyIndex(2, property2, ref reader, ref values)) { }
+                            else if (SetPropertyIndex(3, property3, ref reader, ref values)) { }
+                            else if (SetPropertyIndex(4, property4, ref reader, ref values)) { }
+                            else if (SetPropertyIndex(5, property5, ref reader, ref values)) { }
+                            else if (SetPropertyIndex(6, property6, ref reader, ref values)) { }
+                            else if (SetPropertyIndex(7, property7, ref reader, ref values)) { }
+                            else if (SetPropertyIndex(8, property8, ref reader, ref values)) { }
+                            else if (SetPropertyIndex(9, property9, ref reader, ref values)) { }
+                            else if (SetPropertyIndex(10, property10, ref reader, ref values)) { }
+                            else if (SetPropertyIndex(11, property11, ref reader, ref values)) { }
+                            else if (SetPropertyIndex(12, property12, ref reader, ref values)) { }
+                            else if (SetPropertyIndex(13, property13, ref reader, ref values)) { }
+                            else if (SetPropertyIndex(14, property14, ref reader, ref values)) { }
+                            else if (SetPropertyIndex(15, property15, ref reader, ref values)) { }
+                            else if (SetPropertyIndex(16, property16, ref reader, ref values)) { }
+
+                            if (!reader.Read())
+                                return reader.Suspend((sm, values));
+
+                            sm.OnPropertyNameRead();
+
+                            break;
+
+                        case ObjectReadStateMachine.ReadResult.PropertyValue:
+                            bool ReadPropertyValue<TValue>(IJsonProperty<TValue, JsonReadResult<TValue>> property,
+                                                           ref Utf8JsonReader reader,
+                                                           ref (bool, TValue) value,
+                                                           out JsonReadResult<TResult>? jsonReadResult)
+                            {
+                                switch (property.Reader.TryRead(ref reader))
+                                {
+                                    case { Incomplete: true }:
+                                        jsonReadResult = reader.Suspend((sm, values));
+                                        return false;
+                                    case { Error: { } err }:
+                                        jsonReadResult = new JsonReadError(err);
+                                        return false;
+                                    case { Value: var val }:
+                                        value = (true, val);
+                                        jsonReadResult = null;
+                                        return true;
+                                }
+                            }
+
+                            if (values.NextPropertyIndex is null)
+                            {
+                                if (reader.IsFinalBlock)
+                                    reader.Skip();
+                                else if (!reader.TrySkip())
+                                    return reader.Suspend((sm, values));
+                            }
+
+                            var (valueRead, error) = values.NextPropertyIndex switch
+                            {
+                                1  => (ReadPropertyValue(property1,  ref reader, ref values.P1,  out var e), e),
+                                2  => (ReadPropertyValue(property2,  ref reader, ref values.P2,  out var e), e),
+                                3  => (ReadPropertyValue(property3,  ref reader, ref values.P3,  out var e), e),
+                                4  => (ReadPropertyValue(property4,  ref reader, ref values.P4,  out var e), e),
+                                5  => (ReadPropertyValue(property5,  ref reader, ref values.P5,  out var e), e),
+                                6  => (ReadPropertyValue(property6,  ref reader, ref values.P6,  out var e), e),
+                                7  => (ReadPropertyValue(property7,  ref reader, ref values.P7,  out var e), e),
+                                8  => (ReadPropertyValue(property8,  ref reader, ref values.P8,  out var e), e),
+                                9  => (ReadPropertyValue(property9,  ref reader, ref values.P9,  out var e), e),
+                                10 => (ReadPropertyValue(property10, ref reader, ref values.P10, out var e), e),
+                                11 => (ReadPropertyValue(property11, ref reader, ref values.P11, out var e), e),
+                                12 => (ReadPropertyValue(property12, ref reader, ref values.P12, out var e), e),
+                                13 => (ReadPropertyValue(property13, ref reader, ref values.P13, out var e), e),
+                                14 => (ReadPropertyValue(property14, ref reader, ref values.P14, out var e), e),
+                                15 => (ReadPropertyValue(property15, ref reader, ref values.P15, out var e), e),
+                                16 => (ReadPropertyValue(property16, ref reader, ref values.P16, out var e), e),
+                                null => (true, null),
+                                _  => throw new InvalidOperationException()
+                            };
+
+                            if (!valueRead && error is not null)
+                                return error.Value;
+
+                            sm.OnPropertyValueRead();
+                            values.NextPropertyIndex = null;
+
+                            break;
                     }
                 }
             }
-
-            static void DefaultUnassigned<T>(IJsonProperty<T, JsonReadResult<T>> property, ref (bool, T) v)
-            {
-                if (v is (false, _) && property.HasDefaultValue)
-                    v = (true, property.DefaultValue);
-            }
-
-            DefaultUnassigned(property1, ref value1);
-            DefaultUnassigned(property2, ref value2);
-            DefaultUnassigned(property3, ref value3);
-            DefaultUnassigned(property4, ref value4);
-            DefaultUnassigned(property5, ref value5);
-            DefaultUnassigned(property6, ref value6);
-            DefaultUnassigned(property7, ref value7);
-            DefaultUnassigned(property8, ref value8);
-            DefaultUnassigned(property9, ref value9);
-            DefaultUnassigned(property10, ref value10);
-            DefaultUnassigned(property11, ref value11);
-            DefaultUnassigned(property12, ref value12);
-            DefaultUnassigned(property13, ref value13);
-            DefaultUnassigned(property14, ref value14);
-            DefaultUnassigned(property15, ref value15);
-            DefaultUnassigned(property16, ref value16);
-
-            return (value1, value2, value3,
-                    value4, value5, value6,
-                    value7, value8, value9,
-                    value10, value11, value12,
-                    value13, value14, value15,
-                    value16) is ((true, var v1), (true, var v2), (true, var v3),
-                                 (true, var v4), (true, var v5), (true, var v6),
-                                 (true, var v7), (true, var v8), (true, var v9),
-                                 (true, var v10), (true, var v11), (true, var v12),
-                                 (true, var v13), (true, var v14), (true, var v15),
-                                 (true, var v16))
-                 ? Value(projector(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16))
-                 : Error("Invalid JSON object.");
         });
 
     public static IJsonReader<T[]> Array<T>(IJsonReader<T> itemReader) =>

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -648,22 +648,23 @@ public static partial class JsonReader
                             {
                                 var result = nextPropertyIndex switch
                                 {
-                                    1  => ReadPropertyValue(ref reader, property1,  ref state.Value1,  ref sm, in state),
-                                    2  => ReadPropertyValue(ref reader, property2,  ref state.Value2,  ref sm, in state),
-                                    3  => ReadPropertyValue(ref reader, property3,  ref state.Value3,  ref sm, in state),
-                                    4  => ReadPropertyValue(ref reader, property4,  ref state.Value4,  ref sm, in state),
-                                    5  => ReadPropertyValue(ref reader, property5,  ref state.Value5,  ref sm, in state),
-                                    6  => ReadPropertyValue(ref reader, property6,  ref state.Value6,  ref sm, in state),
-                                    7  => ReadPropertyValue(ref reader, property7,  ref state.Value7,  ref sm, in state),
-                                    8  => ReadPropertyValue(ref reader, property8,  ref state.Value8,  ref sm, in state),
-                                    9  => ReadPropertyValue(ref reader, property9,  ref state.Value9,  ref sm, in state),
-                                    10 => ReadPropertyValue(ref reader, property10, ref state.Value10, ref sm, in state),
-                                    11 => ReadPropertyValue(ref reader, property11, ref state.Value11, ref sm, in state),
-                                    12 => ReadPropertyValue(ref reader, property12, ref state.Value12, ref sm, in state),
-                                    13 => ReadPropertyValue(ref reader, property13, ref state.Value13, ref sm, in state),
-                                    14 => ReadPropertyValue(ref reader, property14, ref state.Value14, ref sm, in state),
-                                    15 => ReadPropertyValue(ref reader, property15, ref state.Value15, ref sm, in state),
-                                    16 => ReadPropertyValue(ref reader, property16, ref state.Value16, ref sm, in state),
+                                    1  => ReadPropertyValue(ref reader, property1,  ref state.Value1,  ref sm, state),
+                                    2  => ReadPropertyValue(ref reader, property2,  ref state.Value2,  ref sm, state),
+                                    3  => ReadPropertyValue(ref reader, property3,  ref state.Value3,  ref sm, state),
+                                    4  => ReadPropertyValue(ref reader, property4,  ref state.Value4,  ref sm, state),
+                                    5  => ReadPropertyValue(ref reader, property5,  ref state.Value5,  ref sm, state),
+                                    6  => ReadPropertyValue(ref reader, property6,  ref state.Value6,  ref sm, state),
+                                    7  => ReadPropertyValue(ref reader, property7,  ref state.Value7,  ref sm, state),
+                                    8  => ReadPropertyValue(ref reader, property8,  ref state.Value8,  ref sm, state),
+                                    9  => ReadPropertyValue(ref reader, property9,  ref state.Value9,  ref sm, state),
+                                    10 => ReadPropertyValue(ref reader, property10, ref state.Value10, ref sm, state),
+                                    11 => ReadPropertyValue(ref reader, property11, ref state.Value11, ref sm, state),
+                                    12 => ReadPropertyValue(ref reader, property12, ref state.Value12, ref sm, state),
+                                    13 => ReadPropertyValue(ref reader, property13, ref state.Value13, ref sm, state),
+                                    14 => ReadPropertyValue(ref reader, property14, ref state.Value14, ref sm, state),
+                                    15 => ReadPropertyValue(ref reader, property15, ref state.Value15, ref sm, state),
+                                    16 => ReadPropertyValue(ref reader, property16, ref state.Value16, ref sm, state),
+                                    var i => throw new SwitchExpressionException(i)
                                     var i => throw new SwitchExpressionException(i)
                                 };
 

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -691,38 +691,39 @@ public static partial class JsonReader
                                 }
                             }
 
-                            if (values.NextPropertyIndex is null)
+                            if (values.NextPropertyIndex is { } nextPropertyIndex)
+                            {
+                                var error = nextPropertyIndex switch
+                                {
+                                    1  => ReadPropertyValue(property1,  ref reader, ref values.P1,  ref sm, ref values),
+                                    2  => ReadPropertyValue(property2,  ref reader, ref values.P2,  ref sm, ref values),
+                                    3  => ReadPropertyValue(property3,  ref reader, ref values.P3,  ref sm, ref values),
+                                    4  => ReadPropertyValue(property4,  ref reader, ref values.P4,  ref sm, ref values),
+                                    5  => ReadPropertyValue(property5,  ref reader, ref values.P5,  ref sm, ref values),
+                                    6  => ReadPropertyValue(property6,  ref reader, ref values.P6,  ref sm, ref values),
+                                    7  => ReadPropertyValue(property7,  ref reader, ref values.P7,  ref sm, ref values),
+                                    8  => ReadPropertyValue(property8,  ref reader, ref values.P8,  ref sm, ref values),
+                                    9  => ReadPropertyValue(property9,  ref reader, ref values.P9,  ref sm, ref values),
+                                    10 => ReadPropertyValue(property10, ref reader, ref values.P10, ref sm, ref values),
+                                    11 => ReadPropertyValue(property11, ref reader, ref values.P11, ref sm, ref values),
+                                    12 => ReadPropertyValue(property12, ref reader, ref values.P12, ref sm, ref values),
+                                    13 => ReadPropertyValue(property13, ref reader, ref values.P13, ref sm, ref values),
+                                    14 => ReadPropertyValue(property14, ref reader, ref values.P14, ref sm, ref values),
+                                    15 => ReadPropertyValue(property15, ref reader, ref values.P15, ref sm, ref values),
+                                    16 => ReadPropertyValue(property16, ref reader, ref values.P16, ref sm, ref values),
+                                    _ => throw new InvalidOperationException()
+                                };
+
+                                if (error is not null)
+                                    return error.Value;
+                            }
+                            else
                             {
                                 if (reader.IsFinalBlock)
                                     reader.Skip();
                                 else if (!reader.TrySkip())
                                     return reader.Suspend((sm, values));
                             }
-
-                            var error = values.NextPropertyIndex switch
-                            {
-                                1  => ReadPropertyValue(property1,  ref reader, ref values.P1,  ref sm, ref values),
-                                2  => ReadPropertyValue(property2,  ref reader, ref values.P2,  ref sm, ref values),
-                                3  => ReadPropertyValue(property3,  ref reader, ref values.P3,  ref sm, ref values),
-                                4  => ReadPropertyValue(property4,  ref reader, ref values.P4,  ref sm, ref values),
-                                5  => ReadPropertyValue(property5,  ref reader, ref values.P5,  ref sm, ref values),
-                                6  => ReadPropertyValue(property6,  ref reader, ref values.P6,  ref sm, ref values),
-                                7  => ReadPropertyValue(property7,  ref reader, ref values.P7,  ref sm, ref values),
-                                8  => ReadPropertyValue(property8,  ref reader, ref values.P8,  ref sm, ref values),
-                                9  => ReadPropertyValue(property9,  ref reader, ref values.P9,  ref sm, ref values),
-                                10 => ReadPropertyValue(property10, ref reader, ref values.P10, ref sm, ref values),
-                                11 => ReadPropertyValue(property11, ref reader, ref values.P11, ref sm, ref values),
-                                12 => ReadPropertyValue(property12, ref reader, ref values.P12, ref sm, ref values),
-                                13 => ReadPropertyValue(property13, ref reader, ref values.P13, ref sm, ref values),
-                                14 => ReadPropertyValue(property14, ref reader, ref values.P14, ref sm, ref values),
-                                15 => ReadPropertyValue(property15, ref reader, ref values.P15, ref sm, ref values),
-                                16 => ReadPropertyValue(property16, ref reader, ref values.P16, ref sm, ref values),
-                                null => null,
-                                _  => throw new InvalidOperationException()
-                            };
-
-                            if (error is not null)
-                                return error.Value;
 
                             sm.OnPropertyValueRead();
                             values.NextPropertyIndex = null;

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -668,8 +668,8 @@ public static partial class JsonReader
                             break;
 
                         case ObjectReadStateMachine.ReadResult.PropertyValue:
-                            static JsonReadResult<TResult>? ReadPropertyValue<T>(IJsonProperty<T, JsonReadResult<T>> property,
-                                                                                 ref Utf8JsonReader reader,
+                            static JsonReadResult<TResult>? ReadPropertyValue<T>(ref Utf8JsonReader reader,
+                                                                                 IJsonProperty<T, JsonReadResult<T>> property,
                                                                                  ref (bool, T) value,
                                                                                  ref ObjectReadStateMachine sm,
                                                                                  in ObjectReadState<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> state)
@@ -690,22 +690,22 @@ public static partial class JsonReader
                             {
                                 var result = nextPropertyIndex switch
                                 {
-                                    1  => ReadPropertyValue(property1,  ref reader, ref state.V1,  ref sm, in state),
-                                    2  => ReadPropertyValue(property2,  ref reader, ref state.V2,  ref sm, in state),
-                                    3  => ReadPropertyValue(property3,  ref reader, ref state.V3,  ref sm, in state),
-                                    4  => ReadPropertyValue(property4,  ref reader, ref state.V4,  ref sm, in state),
-                                    5  => ReadPropertyValue(property5,  ref reader, ref state.V5,  ref sm, in state),
-                                    6  => ReadPropertyValue(property6,  ref reader, ref state.V6,  ref sm, in state),
-                                    7  => ReadPropertyValue(property7,  ref reader, ref state.V7,  ref sm, in state),
-                                    8  => ReadPropertyValue(property8,  ref reader, ref state.V8,  ref sm, in state),
-                                    9  => ReadPropertyValue(property9,  ref reader, ref state.V9,  ref sm, in state),
-                                    10 => ReadPropertyValue(property10, ref reader, ref state.V10, ref sm, in state),
-                                    11 => ReadPropertyValue(property11, ref reader, ref state.V11, ref sm, in state),
-                                    12 => ReadPropertyValue(property12, ref reader, ref state.V12, ref sm, in state),
-                                    13 => ReadPropertyValue(property13, ref reader, ref state.V13, ref sm, in state),
-                                    14 => ReadPropertyValue(property14, ref reader, ref state.V14, ref sm, in state),
-                                    15 => ReadPropertyValue(property15, ref reader, ref state.V15, ref sm, in state),
-                                    16 => ReadPropertyValue(property16, ref reader, ref state.V16, ref sm, in state),
+                                    1  => ReadPropertyValue(ref reader, property1,  ref state.V1,  ref sm, in state),
+                                    2  => ReadPropertyValue(ref reader, property2,  ref state.V2,  ref sm, in state),
+                                    3  => ReadPropertyValue(ref reader, property3,  ref state.V3,  ref sm, in state),
+                                    4  => ReadPropertyValue(ref reader, property4,  ref state.V4,  ref sm, in state),
+                                    5  => ReadPropertyValue(ref reader, property5,  ref state.V5,  ref sm, in state),
+                                    6  => ReadPropertyValue(ref reader, property6,  ref state.V6,  ref sm, in state),
+                                    7  => ReadPropertyValue(ref reader, property7,  ref state.V7,  ref sm, in state),
+                                    8  => ReadPropertyValue(ref reader, property8,  ref state.V8,  ref sm, in state),
+                                    9  => ReadPropertyValue(ref reader, property9,  ref state.V9,  ref sm, in state),
+                                    10 => ReadPropertyValue(ref reader, property10, ref state.V10, ref sm, in state),
+                                    11 => ReadPropertyValue(ref reader, property11, ref state.V11, ref sm, in state),
+                                    12 => ReadPropertyValue(ref reader, property12, ref state.V12, ref sm, in state),
+                                    13 => ReadPropertyValue(ref reader, property13, ref state.V13, ref sm, in state),
+                                    14 => ReadPropertyValue(ref reader, property14, ref state.V14, ref sm, in state),
+                                    15 => ReadPropertyValue(ref reader, property15, ref state.V15, ref sm, in state),
+                                    16 => ReadPropertyValue(ref reader, property16, ref state.V16, ref sm, in state),
                                     var i => throw new SwitchExpressionException(i)
                                 };
 

--- a/src/ObjectReadStateMachine.cs
+++ b/src/ObjectReadStateMachine.cs
@@ -33,6 +33,7 @@ public record struct ObjectReadStateMachine
             switch (CurrentState)
             {
                 case State.Initial:
+                {
                     if (reader.TokenType is JsonTokenType.None && !reader.Read())
                         return ReadResult.Incomplete;
 
@@ -44,8 +45,10 @@ public record struct ObjectReadStateMachine
 
                     CurrentState = State.PropertyNameOrEnd;
                     break;
+                }
 
                 case State.PropertyNameOrEnd:
+                {
                     if (!reader.Read())
                         return ReadResult.Incomplete;
 
@@ -57,6 +60,7 @@ public record struct ObjectReadStateMachine
 
                     CurrentState = State.PendingPropertyNameRead;
                     return ReadResult.PropertyName;
+                }
 
                 case State.PendingPropertyNameRead:
                     return ReadResult.PropertyName;

--- a/src/ObjectReadStateMachine.cs
+++ b/src/ObjectReadStateMachine.cs
@@ -1,0 +1,79 @@
+// Copyright (c) 2021 Atif Aziz.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Jacob;
+
+using System;
+using System.Text.Json;
+
+public record struct ObjectReadStateMachine
+{
+    public enum State { Initial, PropertyNameOrEnd, PendingPropertyNameRead, PendingPropertyValueRead, Done, Error }
+    public enum ReadResult { Error, Incomplete, PropertyName, PropertyValue, Done }
+
+    public State CurrentState { get; private set; }
+    public int CurrentLength { get; private set; }
+    public int CurrentPropertyLoopCount { get; private set; }
+
+    public void OnPropertyNameRead() =>
+        (CurrentState, CurrentPropertyLoopCount, CurrentLength) =
+            CurrentState is State.PendingPropertyNameRead
+            ? (State.PendingPropertyValueRead, -1, CurrentLength + 1)
+            : throw new InvalidOperationException();
+
+    public void OnPropertyValueRead() =>
+        (CurrentState, CurrentPropertyLoopCount, CurrentLength) =
+            CurrentState is State.PendingPropertyValueRead
+            ? (State.PropertyNameOrEnd, 0, CurrentLength + 1)
+            : throw new InvalidOperationException();
+
+    public ReadResult Read(ref Utf8JsonReader reader)
+    {
+        while (true)
+        {
+            switch (CurrentState)
+            {
+                case State.Initial:
+                    if (reader.TokenType is JsonTokenType.None && !reader.Read())
+                        return ReadResult.Incomplete;
+
+                    if (reader.TokenType is not JsonTokenType.StartObject)
+                    {
+                        CurrentState = State.Error;
+                        return ReadResult.Error;
+                    }
+
+                    CurrentState = State.PropertyNameOrEnd;
+                    break;
+
+                case State.PropertyNameOrEnd:
+                    var lookahead = reader;
+
+                    if (!lookahead.Read())
+                        return ReadResult.Incomplete;
+
+                    if (lookahead.TokenType is JsonTokenType.EndObject)
+                    {
+                        reader = lookahead;
+                        CurrentState = State.Done;
+                        return ReadResult.Done;
+                    }
+
+                    CurrentState = State.PendingPropertyNameRead;
+                    return ReadResult.PropertyName;
+
+                case State.PendingPropertyNameRead:
+                    CurrentPropertyLoopCount++;
+                    return ReadResult.PropertyName;
+
+                case State.PendingPropertyValueRead:
+                    CurrentPropertyLoopCount++;
+                    return ReadResult.PropertyValue;
+
+                default:
+                    throw new InvalidOperationException();
+            }
+        }
+    }
+}

--- a/src/ObjectReadStateMachine.cs
+++ b/src/ObjectReadStateMachine.cs
@@ -18,7 +18,7 @@ public record struct ObjectReadStateMachine
     public void OnPropertyNameRead() =>
         (CurrentState, CurrentPropertyLoopCount) =
             CurrentState is State.PendingPropertyNameRead
-            ? (State.PendingPropertyValueRead, 0)
+            ? (State.PendingPropertyValueRead, -1)
             : throw new InvalidOperationException();
 
     public void OnPropertyValueRead() =>

--- a/src/ObjectReadStateMachine.cs
+++ b/src/ObjectReadStateMachine.cs
@@ -13,19 +13,18 @@ public record struct ObjectReadStateMachine
     public enum ReadResult { Error, Incomplete, PropertyName, PropertyValue, Done }
 
     public State CurrentState { get; private set; }
-    public int CurrentLength { get; private set; }
     public int CurrentPropertyLoopCount { get; private set; }
 
     public void OnPropertyNameRead() =>
-        (CurrentState, CurrentPropertyLoopCount, CurrentLength) =
+        (CurrentState, CurrentPropertyLoopCount) =
             CurrentState is State.PendingPropertyNameRead
-            ? (State.PendingPropertyValueRead, -1, CurrentLength + 1)
+            ? (State.PendingPropertyValueRead, 0)
             : throw new InvalidOperationException();
 
     public void OnPropertyValueRead() =>
-        (CurrentState, CurrentPropertyLoopCount, CurrentLength) =
+        (CurrentState, CurrentPropertyLoopCount) =
             CurrentState is State.PendingPropertyValueRead
-            ? (State.PropertyNameOrEnd, 0, CurrentLength + 1)
+            ? (State.PropertyNameOrEnd, 0)
             : throw new InvalidOperationException();
 
     public ReadResult Read(ref Utf8JsonReader reader)

--- a/src/ObjectReadStateMachine.cs
+++ b/src/ObjectReadStateMachine.cs
@@ -46,7 +46,6 @@ public record struct ObjectReadStateMachine
                     CurrentState = State.PropertyNameOrEnd;
                     break;
                 }
-
                 case State.PropertyNameOrEnd:
                 {
                     if (!reader.Read())
@@ -61,10 +60,10 @@ public record struct ObjectReadStateMachine
                     CurrentState = State.PendingPropertyNameRead;
                     return ReadResult.PropertyName;
                 }
-
                 case State.PendingPropertyNameRead:
+                {
                     return ReadResult.PropertyName;
-
+                }
                 case State.PropertyValue:
                 {
                     if (!reader.Read())
@@ -73,12 +72,14 @@ public record struct ObjectReadStateMachine
                     CurrentState = State.PendingPropertyValueRead;
                     return ReadResult.PropertyValue;
                 }
-
                 case State.PendingPropertyValueRead:
+                {
                     return ReadResult.PropertyValue;
-
+                }
                 default:
+                {
                     throw new InvalidOperationException();
+                }
             }
         }
     }

--- a/tests/ObjectReadStateMachineTests.cs
+++ b/tests/ObjectReadStateMachineTests.cs
@@ -86,7 +86,7 @@ public sealed class ObjectReadStateMachineTests
     public void Read_Increments_CurrentPropertyLoopCount_When_Current_State_Is_PendingPropertyNameRead()
     {
         var subject = new ObjectReadStateMachine();
-        var reader = new Utf8JsonReader("{\"foo\":"u8, isFinalBlock: false, new());
+        var reader = new Utf8JsonReader("""{"foo":"""u8, isFinalBlock: false, new());
 
         foreach (var _ in Enumerable.Range(0, 10))
         {

--- a/tests/ObjectReadStateMachineTests.cs
+++ b/tests/ObjectReadStateMachineTests.cs
@@ -6,7 +6,6 @@ namespace Jacob.Tests;
 
 using MoreLinq;
 using System;
-using System.Linq;
 using System.Text;
 using Xunit;
 using JsonTokenType = System.Text.Json.JsonTokenType;
@@ -80,39 +79,6 @@ public sealed class ObjectReadStateMachineTests
 
         var ex = CatchExceptionForAssertion(reader, r => _ = subject.Read(ref r));
         _ = Assert.IsType<InvalidOperationException>(ex);
-    }
-
-    [Fact]
-    public void Read_Increments_CurrentPropertyLoopCount_When_Current_State_Is_PendingPropertyNameRead()
-    {
-        var subject = new ObjectReadStateMachine();
-        var reader = new Utf8JsonReader("""{"foo":"""u8, isFinalBlock: false, new());
-
-        foreach (var _ in Enumerable.Range(0, 10))
-        {
-            var result = subject.Read(ref reader);
-
-            Assert.Equal(ReadResult.PropertyName, result);
-            Assert.Equal(State.PendingPropertyNameRead, subject.CurrentState);
-        }
-    }
-
-    [Fact]
-    public void Read_Increments_CurrentPropertyLoopCount_When_Current_State_Is_PendingPropertyValueRead()
-    {
-        var subject = new ObjectReadStateMachine();
-        var reader = new Utf8JsonReader("""{"foo":4"""u8, isFinalBlock: false, new());
-
-        _ = subject.Read(ref reader);
-        subject.OnPropertyNameRead();
-
-        foreach (var _ in Enumerable.Range(0, 10))
-        {
-            var result = subject.Read(ref reader);
-
-            Assert.Equal(ReadResult.PropertyValue, result);
-            Assert.Equal(State.PendingPropertyValueRead, subject.CurrentState);
-        }
     }
 
     public static readonly TheoryData<string[], (ReadResult, State)[]> Read_Reads_Object_Data =

--- a/tests/ObjectReadStateMachineTests.cs
+++ b/tests/ObjectReadStateMachineTests.cs
@@ -101,7 +101,7 @@ public sealed class ObjectReadStateMachineTests
     public void Read_Increments_CurrentPropertyLoopCount_When_Current_State_Is_PendingPropertyValueRead()
     {
         var subject = new ObjectReadStateMachine();
-        var reader = new Utf8JsonReader("{\"foo\":4"u8, isFinalBlock: false, new());
+        var reader = new Utf8JsonReader("""{"foo":4"""u8, isFinalBlock: false, new());
 
         _ = subject.Read(ref reader);
         subject.OnPropertyNameRead();
@@ -158,7 +158,7 @@ public sealed class ObjectReadStateMachineTests
                 }
             },
             {
-                new[] { "{", """ "f """, """ oo": """, """ "bar" """, "}" },
+                new[] { "{", """ "f""", """oo": """, """ "bar" """, "}" },
                 new[]
                 {
                     (ReadResult.Incomplete, State.PropertyNameOrEnd),
@@ -169,7 +169,7 @@ public sealed class ObjectReadStateMachineTests
                 }
             },
             {
-                new[] { "{", """ "foo": """, """ "ba """, """ r" """, "}" },
+                new[] { "{", """ "foo": """, """ "ba""", """r" """, "}" },
                 new[]
                 {
                     (ReadResult.Incomplete, State.PropertyNameOrEnd),
@@ -180,7 +180,7 @@ public sealed class ObjectReadStateMachineTests
                 }
             },
             {
-                new[] { "{", "\"", "f", "o", "o", "\"", ":", "4","2", "}" },
+                new[] { "{", "\"", "f", "o", "o", "\"", ":", "4", "2", "}" },
                 new[]
                 {
                     (ReadResult.Incomplete, State.PropertyNameOrEnd),
@@ -220,7 +220,7 @@ public sealed class ObjectReadStateMachineTests
                 }
             },
             {
-                new[] { """ { "foo": """, /*lang=json*/ """ {"bar":42} """, "}" },
+                new[] { """ {"foo": """, /*lang=json*/ """ {"bar":42} """, "}" },
                 new[]
                 {
                     (ReadResult.PropertyName, State.PendingPropertyNameRead),

--- a/tests/ObjectReadStateMachineTests.cs
+++ b/tests/ObjectReadStateMachineTests.cs
@@ -1,0 +1,136 @@
+// Copyright (c) 2021 Atif Aziz.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Jacob.Tests;
+
+using System;
+using System.Linq;
+using System.Text;
+using Xunit;
+using ReadResult = ObjectReadStateMachine.ReadResult;
+using State = ObjectReadStateMachine.State;
+
+public sealed class ObjectReadStateMachineTests
+{
+    [Fact]
+    public void Default_Instance_Is_Initialized()
+    {
+        var subject = new ObjectReadStateMachine();
+        Assert.Equal(State.Initial, subject.CurrentState);
+        Assert.Equal(0, subject.CurrentPropertyLoopCount);
+    }
+
+    [Fact]
+    public void OnPropertyNameRead_Throws_When_CurrentState_Is_Not_PendingPropertyNameRead()
+    {
+        var subject = new ObjectReadStateMachine();
+        _ = Assert.Throws<InvalidOperationException>(subject.OnPropertyNameRead);
+    }
+
+    [Fact]
+    public void OnPropertyValueRead_Throws_When_CurrentState_Is_Not_PendingPropertyValueRead()
+    {
+        var subject = new ObjectReadStateMachine();
+        _ = Assert.Throws<InvalidOperationException>(subject.OnPropertyValueRead);
+    }
+
+    [Theory]
+    [InlineData(/*lang=json*/ "null")]
+    [InlineData(/*lang=json*/ "true")]
+    [InlineData(/*lang=json*/ "false")]
+    [InlineData(/*lang=json*/ "42")]
+    [InlineData(/*lang=json*/ """ "foobar" """)]
+    [InlineData(/*lang=json*/ "[]")]
+    public void Read_With_Invalid_Input_Is_An_Error(string json)
+    {
+        var subject = new ObjectReadStateMachine();
+        var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json));
+
+        var result = subject.Read(ref reader);
+
+        Assert.Equal(ReadResult.Error, result);
+        Assert.Equal(State.Error, subject.CurrentState);
+    }
+
+    [Fact]
+    public void Read_Throws_When_State_Machine_Is_In_Error_State()
+    {
+        var subject = new ObjectReadStateMachine();
+        var reader = new Utf8JsonReader("["u8);
+
+        _ = subject.Read(ref reader);
+
+        Assert.Equal(State.Error, subject.CurrentState);
+
+        var ex = CatchExceptionForAssertion(reader, r => _ = subject.Read(ref r));
+        _ = Assert.IsType<InvalidOperationException>(ex);
+    }
+
+    [Fact]
+    public void Read_Throws_When_State_Machine_Is_In_Done_State()
+    {
+        var subject = new ObjectReadStateMachine();
+        var reader = new Utf8JsonReader("{}"u8);
+
+        _ = subject.Read(ref reader);
+
+        Assert.Equal(State.Done, subject.CurrentState);
+
+        var ex = CatchExceptionForAssertion(reader, r => _ = subject.Read(ref r));
+        _ = Assert.IsType<InvalidOperationException>(ex);
+    }
+
+    [Fact]
+    public void Read_Increments_CurrentPropertyLoopCount_When_Current_State_Is_PendingPropertyNameRead()
+    {
+        var subject = new ObjectReadStateMachine();
+        var reader = new Utf8JsonReader("{\"foo\":"u8, isFinalBlock: false, new());
+
+        foreach (var i in Enumerable.Range(0, 10))
+        {
+            var result = subject.Read(ref reader);
+
+            Assert.Equal(ReadResult.PropertyName, result);
+            Assert.Equal(State.PendingPropertyNameRead, subject.CurrentState);
+            Assert.Equal(i, subject.CurrentPropertyLoopCount);
+        }
+    }
+
+    [Fact]
+    public void Read_Increments_CurrentPropertyLoopCount_When_Current_State_Is_PendingPropertyValueRead()
+    {
+        var subject = new ObjectReadStateMachine();
+        var reader = new Utf8JsonReader("{\"foo\":4"u8, isFinalBlock: false, new());
+
+        _ = subject.Read(ref reader);
+        subject.OnPropertyNameRead();
+
+        foreach (var i in Enumerable.Range(0, 10))
+        {
+            var result = subject.Read(ref reader);
+
+            Assert.Equal(ReadResult.PropertyValue, result);
+            Assert.Equal(State.PendingPropertyValueRead, subject.CurrentState);
+            Assert.Equal(i, subject.CurrentPropertyLoopCount);
+        }
+    }
+
+    delegate void ReaderAction(Utf8JsonReader reader);
+
+    static Exception? CatchExceptionForAssertion(Utf8JsonReader reader, ReaderAction action)
+    {
+        try
+        {
+            action(reader);
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            return ex;
+        }
+
+        return null;
+    }
+}

--- a/tests/ObjectReadStateMachineTests.cs
+++ b/tests/ObjectReadStateMachineTests.cs
@@ -20,7 +20,6 @@ public sealed class ObjectReadStateMachineTests
     {
         var subject = new ObjectReadStateMachine();
         Assert.Equal(State.Initial, subject.CurrentState);
-        Assert.Equal(0, subject.CurrentPropertyLoopCount);
     }
 
     [Fact]
@@ -89,13 +88,12 @@ public sealed class ObjectReadStateMachineTests
         var subject = new ObjectReadStateMachine();
         var reader = new Utf8JsonReader("{\"foo\":"u8, isFinalBlock: false, new());
 
-        foreach (var i in Enumerable.Range(0, 10))
+        foreach (var _ in Enumerable.Range(0, 10))
         {
             var result = subject.Read(ref reader);
 
             Assert.Equal(ReadResult.PropertyName, result);
             Assert.Equal(State.PendingPropertyNameRead, subject.CurrentState);
-            Assert.Equal(i, subject.CurrentPropertyLoopCount);
         }
     }
 
@@ -108,13 +106,12 @@ public sealed class ObjectReadStateMachineTests
         _ = subject.Read(ref reader);
         subject.OnPropertyNameRead();
 
-        foreach (var i in Enumerable.Range(0, 10))
+        foreach (var _ in Enumerable.Range(0, 10))
         {
             var result = subject.Read(ref reader);
 
             Assert.Equal(ReadResult.PropertyValue, result);
             Assert.Equal(State.PendingPropertyValueRead, subject.CurrentState);
-            Assert.Equal(i, subject.CurrentPropertyLoopCount);
         }
     }
 
@@ -263,8 +260,6 @@ public sealed class ObjectReadStateMachineTests
 
             if (result is ReadResult.PropertyName)
             {
-                var read = reader.Read();
-                Assert.True(read);
                 subject.OnPropertyNameRead();
                 Assert.Equal(State.PendingPropertyValueRead, subject.CurrentState);
             }


### PR DESCRIPTION
With this PR also `JsonReader.Object` supports partial, resumable reading. The implementation is like `JsonReader.Array` and relies on a state machine to track the current progress of the object reading. The state machine works slightly different to the array version: after a property name is read, it is left to the caller to read the property value fully, as this helps avoiding unnecessary lookaheads within the state machine.