### PR TITLE
Remove look-ahead in `ArrayReadStateMachine`

### DIFF
--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -175,12 +175,6 @@ public static partial class JsonReader
                     }
                     case ArrayReadStateMachine.ReadResult.Item:
                     {
-                        if (ar.CurrentItemLoopCount is 0)
-                        {
-                            var read = rdr.Read();
-                            Debug.Assert(read);
-                        }
-
                         switch (reader.TryRead(ref rdr))
                         {
                             case var r when r.IsIncomplete():
@@ -702,12 +696,6 @@ public static partial class JsonReader
 
                         case ArrayReadStateMachine.ReadResult.Item:
                         {
-                            if (sm.CurrentItemLoopCount is 0)
-                            {
-                                var read = rdr.Read();
-                                Debug.Assert(read);
-                            }
-
                             switch (itemReader.TryRead(ref rdr))
                             {
                                 case var r when r.IsIncomplete():

--- a/tests/ArrayReadStateMachineTests.cs
+++ b/tests/ArrayReadStateMachineTests.cs
@@ -21,7 +21,6 @@ public class ArrayReadStateMachineTests
         var subject = new ArrayReadStateMachine();
         Assert.Equal(State.Initial, subject.CurrentState);
         Assert.Equal(0, subject.CurrentLength);
-        Assert.Equal(0, subject.CurrentItemLoopCount);
     }
 
     [Fact]
@@ -90,7 +89,6 @@ public class ArrayReadStateMachineTests
             Assert.Equal(ReadResult.Item, result);
             Assert.Equal(State.PendingItemRead, subject.CurrentState);
             Assert.Equal(0, subject.CurrentLength);
-            Assert.Equal(i, subject.CurrentItemLoopCount);
         }
     }
 
@@ -238,9 +236,6 @@ public class ArrayReadStateMachineTests
 
             if (result is ReadResult.Item)
             {
-                var read = reader.Read();
-                Assert.True(read);
-
                 if (reader.TokenType is JsonTokenType.StartObject or JsonTokenType.StartArray)
                 {
                     var skipped = reader.TrySkip();


### PR DESCRIPTION
This PR removes the look-ahead from the `ArrayReadStateMachine` that wasn't needed, but which was hurting performance. As a side-effect, it also removes `ArrayReadStateMachine.CurrentItemLoopCount`.