### PR TITLE
Make reader argument to `IJsonProperty.IsMatch` read-only

### DIFF
--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -70,7 +70,7 @@ public interface IJsonReader<T> : IJsonReader<T, JsonReadResult<T>> { }
 public interface IJsonProperty<out T, out TReadResult>
     where TReadResult : IJsonReadResult<T>
 {
-    bool IsMatch(ref Utf8JsonReader reader);
+    bool IsMatch(in Utf8JsonReader reader);
     IJsonReader<T, TReadResult> Reader { get; }
     bool HasDefaultValue { get; }
     T DefaultValue { get; }
@@ -447,7 +447,7 @@ public static partial class JsonReader
         public JsonProperty(string name, IJsonReader<T> reader, (bool, T) @default = default) =>
             (this.name, Reader, (HasDefaultValue, DefaultValue)) = (name, reader, @default);
 
-        public bool IsMatch(ref Utf8JsonReader reader) =>
+        public bool IsMatch(in Utf8JsonReader reader) =>
             reader.TokenType != JsonTokenType.PropertyName
                 ? throw new ArgumentException(null, nameof(reader))
                 : reader.ValueTextEquals(this.name);
@@ -466,7 +466,7 @@ public static partial class JsonReader
 
         NonProperty() { }
 
-        public bool IsMatch(ref Utf8JsonReader reader) => false;
+        public bool IsMatch(in Utf8JsonReader reader) => false;
         public IJsonReader<Unit, JsonReadResult<Unit>> Reader => throw new NotSupportedException();
         public bool HasDefaultValue => true;
         public Unit DefaultValue => default;
@@ -595,7 +595,7 @@ public static partial class JsonReader
                                                                ref Utf8JsonReader reader,
                                                                ref int? currentIndex)
                             {
-                                if (!property.IsMatch(ref reader))
+                                if (!property.IsMatch(reader))
                                     return false;
 
                                 currentIndex = index;

--- a/tests/JsonReaderTests.cs
+++ b/tests/JsonReaderTests.cs
@@ -565,7 +565,7 @@ public abstract class JsonReaderTestsBase
         _ = reader.Read(); // "{"
         _ = reader.Read(); // property
 
-        Assert.True(property.IsMatch(ref reader));
+        Assert.True(property.IsMatch(reader));
         Assert.Same(valueReader, property.Reader);
         Assert.False(property.HasDefaultValue);
         Assert.Null(property.DefaultValue);
@@ -585,7 +585,7 @@ public abstract class JsonReaderTestsBase
         _ = reader.Read(); // "{"
         _ = reader.Read(); // property
 
-        Assert.True(property.IsMatch(ref reader));
+        Assert.True(property.IsMatch(reader));
         Assert.True(property.HasDefaultValue);
         Assert.Same(defaultValue, property.DefaultValue);
         Assert.Same(valueReader, property.Reader);
@@ -602,7 +602,7 @@ public abstract class JsonReaderTestsBase
             const string json = /*lang=json*/ """{ "foobar": 42 }""";
             var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json));
             _ = reader.Read(); // "{"
-            return _ = property.IsMatch(ref reader);
+            return _ = property.IsMatch(reader);
         });
 
         Assert.Equal("reader", ex.ParamName);


### PR DESCRIPTION
Implementations of `IJsonProperty.IsMatch` are not expected to update the reader so this PR enforces that by fixing the `ref` modifier to `in`.