### PR TITLE
Support partial reading for `JsonReader.Object` (general)

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,6 @@ of the JSON source text to resume reading.
 
 Presently, the following readers do not support partial reading:
 
-- `JsonReader.Object`
 - `JsonReader.Either`
 - `JsonReader.Tuple`
 

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -474,7 +474,7 @@ public static partial class JsonReader
 
     public static IJsonReader<TResult> Object<T, TResult>(IJsonReader<T> reader,
                                                           Func<List<KeyValuePair<string, T>>, TResult> resultSelector) =>
-        Create((ref Utf8JsonReader rdr) =>
+        CreatePure((ref Utf8JsonReader rdr) =>
         {
             var (sm, currentPropertyName, acc) =
                 rdr.IsResuming && ((ObjectReadStateMachine, string?, List<KeyValuePair<string, T>>))rdr.Pop() is var ps

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -504,7 +504,7 @@ public static partial class JsonReader
                         switch (reader.TryRead(ref rdr))
                         {
                             case { Incomplete: true }:
-                                return rdr.Suspend((sm, currentPropertyName));
+                                return rdr.Suspend((sm, currentPropertyName, acc));
                             case { Error: { } err }:
                                 return new JsonReadError(err);
                             case { Value: var val }:

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -508,7 +508,8 @@ public static partial class JsonReader
                             case { Error: { } err }:
                                 return new JsonReadError(err);
                             case { Value: var val }:
-                                acc.Add(KeyValuePair.Create(currentPropertyName!, val));
+                                Debug.Assert(currentPropertyName is not null);
+                                acc.Add(KeyValuePair.Create(currentPropertyName, val));
                                 break;
                         }
 

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -477,8 +477,8 @@ public static partial class JsonReader
         CreatePure((ref Utf8JsonReader rdr) =>
         {
             var (sm, currentPropertyName, acc) =
-                rdr.IsResuming && ((ObjectReadStateMachine, string?, List<KeyValuePair<string, T>>))rdr.Pop() is var ps
-                    ? ps
+                rdr.IsResuming
+                    ? ((ObjectReadStateMachine, string?, List<KeyValuePair<string, T>>))rdr.Pop()
                     : (default, default, new());
 
             while (true)

--- a/tests/JsonReaderTests.cs
+++ b/tests/JsonReaderTests.cs
@@ -657,6 +657,27 @@ public abstract class JsonReaderTestsBase
         TestValidInput(KeyIntMapReader, json, new() { ["foo"] = 123, ["bar"] = 456, ["baz"] = 789 });
     }
 
+    static readonly IJsonReader<Dictionary<string, Dictionary<string, string>>> NestedObjectReader =
+        JsonReader.Object(JsonReader.Object(JsonReader.String(),
+                                            ps => ps.ToDictionary(e => e.Key, e => e.Value)),
+                          ps => ps.ToDictionary(e => e.Key, e => e.Value));
+
+    [Fact]
+    public void Object_General_With_Nested_Property_And_Valid_Input()
+    {
+        const string json = /*lang=json*/ """{ "foo": { "bar": "foobarbaz" } }""";
+
+        TestValidInput(NestedObjectReader, json, new() { ["foo"] = new() { ["bar"] = "foobarbaz" } });
+    }
+
+    [Fact]
+    public void Object_General_With_Nested_Property_And_Invalid_Input()
+    {
+        const string json = /*lang=json*/ """{ "foo": { "bar": { "baz": "foo" } } }""";
+
+        TestInvalidInput(NestedObjectReader, json, "Invalid JSON value where a JSON string was expected.", "StartObject", 16);
+    }
+
     [Theory]
     [InlineData("Invalid JSON value where a JSON object was expected.", "Null", /*lang=json*/ "null")]
     [InlineData("Invalid JSON value where a JSON object was expected.", "False", /*lang=json*/ "false")]

--- a/tests/JsonReaderTests.cs
+++ b/tests/JsonReaderTests.cs
@@ -675,7 +675,7 @@ public abstract class JsonReaderTestsBase
     {
         const string json = /*lang=json*/ """{ "foo": { "bar": { "baz": "foo" } } }""";
 
-        TestInvalidInput(NestedObjectReader, json, "Invalid JSON value where a JSON string was expected.", "StartObject", 16);
+        TestInvalidInput(NestedObjectReader, json, "Invalid JSON value where a JSON string was expected.", "StartObject", 18);
     }
 
     [Theory]

--- a/tests/JsonReaderTests.cs
+++ b/tests/JsonReaderTests.cs
@@ -663,7 +663,7 @@ public abstract class JsonReaderTestsBase
                           ps => ps.ToDictionary(e => e.Key, e => e.Value));
 
     [Fact]
-    public void Object_General_With_Nested_Property_And_Valid_Input()
+    public void Object_General_Nested_With_Valid_Input()
     {
         const string json = /*lang=json*/ """{ "foo": { "bar": "foobarbaz" } }""";
 
@@ -671,7 +671,7 @@ public abstract class JsonReaderTestsBase
     }
 
     [Fact]
-    public void Object_General_With_Nested_Property_And_Invalid_Input()
+    public void Object_General_Nested_With_Invalid_Input()
     {
         const string json = /*lang=json*/ """{ "foo": { "bar": { "baz": "foo" } } }""";
 


### PR DESCRIPTION
As a follow-up of #21, this PR introduces support for partial JSON reading on the other overload of `JsonReader.Object`. The existing test already cover a streamed and non-streamed version of `JsonReader.Object`, hence this PR contains no additional tests. 