### PR TITLE
Remove test data airport reader buffering

### DIFF
--- a/tests/AsyncStreamTests.cs
+++ b/tests/AsyncStreamTests.cs
@@ -76,7 +76,7 @@ public class AsyncStreamTests
     [Fact]
     public async Task GetAsyncEnumerator_With_Airports_Data()
     {
-        var jsonReader = AirportReader.Buffer();
+        var jsonReader = AirportReader;
         Airport? lastGoodAirport = null;
         var actual = new List<Airport>();
 


### PR DESCRIPTION
Give #21, the buffering of the test data airport reader is no longer required. This PR therefore removes that buffering.