### PR TITLE
Partial reading for `JsonReader.Either`

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,11 +236,7 @@ then the `Incomplete` property of the returned `JsonReadResult<T>` will be
 `true`. This is a signal to the caller that it must load the buffer with more
 of the JSON source text to resume reading.
 
-Presently, the following readers do not support partial reading:
-
-- `JsonReader.Either`
-
-Nevertheless, they can be composed with `JsonReader.Buffer` to load enough
+All readers can be composed with `JsonReader.Buffer` to load enough
 data into the buffer that neither can fail due to partial JSON.
 `JsonReader.Buffer` ensures that at least one complete JSON value (be that a
 scalar like a string or a structure like an array or an object) is buffered.

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ then the `Incomplete` property of the returned `JsonReadResult<T>` will be
 of the JSON source text to resume reading.
 
 All readers can be composed with `JsonReader.Buffer` to load enough
-data into the buffer that neither can fail due to partial JSON.
+data into the buffer so that none can fail due to partial JSON.
 `JsonReader.Buffer` ensures that at least one complete JSON value (be that a
 scalar like a string or a structure like an array or an object) is buffered.
 

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -511,8 +511,6 @@ public static partial class JsonReader
                 }
             }
 
-            var rightRead = false;
-
             if (!rightError)
             {
                 var rdrStack = rdr.SwapStack(rightStack);
@@ -531,10 +529,9 @@ public static partial class JsonReader
                 }
 
                 _ = rdr.SwapStack(rdrStack);
-                rightRead = true;
             }
 
-            if (!rightRead || (rightError && !leftError))
+            if (rightError && !leftError)
             {
                 _ = leftRdr.SwapStack(rdr.CurrentState.Stack);
                 rdr = leftRdr;

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -949,9 +949,6 @@ public static partial class JsonReader
         return recReader;
     }
 
-    static NotSupportedException PartialJsonNotSupportedException() =>
-        new($"Partial JSON reading is not supported. Combine with {nameof(Buffer)}.");
-
     static IJsonReader<T> Create<T>(Handler<T> handler) =>
         new DelegatingJsonReader<T>(handler);
 

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -539,7 +539,7 @@ public static partial class JsonReader
                 case (_   , true, false):
                 case (true, true, true ):
                     break;
-                case (_   , _   , _    ):
+                default:
                 {
                     _ = leftRdr.SwapStack(rdr.CurrentState.Stack);
                     rdr = leftRdr;

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -537,7 +537,7 @@ public static partial class JsonReader
             switch (leftError, rightRead, rightError)
             {
                 case (_   , true, false):
-                case (true, true, _    ):
+                case (true, true, true ):
                     break;
                 case (_   , _   , _    ):
                 {

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -534,18 +534,11 @@ public static partial class JsonReader
                 rightRead = true;
             }
 
-            switch (leftError, rightRead, rightError)
+            if (!rightRead || (rightError && !leftError))
             {
-                case (_   , true, false):
-                case (true, true, true ):
-                    break;
-                default:
-                {
-                    _ = leftRdr.SwapStack(rdr.CurrentState.Stack);
-                    rdr = leftRdr;
-                    break;
-                }
-            };
+                _ = leftRdr.SwapStack(rdr.CurrentState.Stack);
+                rdr = leftRdr;
+            }
 
             if (leftError && rightError)
                 return Error(errorMessage ?? "Invalid JSON value.");

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -498,7 +498,7 @@ public static partial class JsonReader
 
             if (leftState is EitherSideState.Incomplete)
             {
-                leftRdr.ReplaceStack(leftStack);
+                leftRdr.SetStack(leftStack);
 
                 switch (reader1.TryRead(ref leftRdr))
                 {
@@ -509,7 +509,7 @@ public static partial class JsonReader
                         leftState = EitherSideState.Error;
                         break;
                     case var some:
-                        leftRdr.ReplaceStack(initialStack);
+                        leftRdr.SetStack(initialStack);
                         rdr = leftRdr;
                         return some;
                 }
@@ -517,7 +517,7 @@ public static partial class JsonReader
 
             if (rightState is EitherSideState.Incomplete)
             {
-                rdr.ReplaceStack(rightStack);
+                rdr.SetStack(rightStack);
 
                 switch (reader2.TryRead(ref rdr))
                 {
@@ -528,7 +528,7 @@ public static partial class JsonReader
                         rightState = EitherSideState.Error;
                         break;
                     case var some:
-                        rdr.ReplaceStack(initialStack);
+                        rdr.SetStack(initialStack);
                         return some;
                 }
             }
@@ -536,7 +536,7 @@ public static partial class JsonReader
             if (rightState is EitherSideState.Error && leftState is EitherSideState.Incomplete)
                 rdr = leftRdr;
 
-            rdr.ReplaceStack(initialStack);
+            rdr.SetStack(initialStack);
 
             if (leftState is EitherSideState.Error && rightState is EitherSideState.Error)
                 return Error(errorMessage ?? "Invalid JSON value.");

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -494,6 +494,7 @@ public static partial class JsonReader
 
             var leftRdr = rdr;
             var initialStack = rdr.CurrentState.Stack;
+            Debug.Assert(initialStack is null or { Count: 0 });
 
             if (leftState is EitherSideState.Incomplete)
             {

--- a/src/JsonReader.cs
+++ b/src/JsonReader.cs
@@ -498,7 +498,7 @@ public static partial class JsonReader
 
             if (leftState is EitherSideState.Incomplete)
             {
-                _ = leftRdr.SwapStack(leftStack);
+                leftRdr.ReplaceStack(leftStack);
 
                 switch (reader1.TryRead(ref leftRdr))
                 {
@@ -509,7 +509,7 @@ public static partial class JsonReader
                         leftState = EitherSideState.Error;
                         break;
                     case var some:
-                        _ = leftRdr.SwapStack(initialStack);
+                        leftRdr.ReplaceStack(initialStack);
                         rdr = leftRdr;
                         return some;
                 }
@@ -517,7 +517,7 @@ public static partial class JsonReader
 
             if (rightState is EitherSideState.Incomplete)
             {
-                _ = rdr.SwapStack(rightStack);
+                rdr.ReplaceStack(rightStack);
 
                 switch (reader2.TryRead(ref rdr))
                 {
@@ -528,7 +528,7 @@ public static partial class JsonReader
                         rightState = EitherSideState.Error;
                         break;
                     case var some:
-                        _ = rdr.SwapStack(initialStack);
+                        rdr.ReplaceStack(initialStack);
                         return some;
                 }
             }
@@ -536,7 +536,7 @@ public static partial class JsonReader
             if (rightState is EitherSideState.Error && leftState is EitherSideState.Incomplete)
                 rdr = leftRdr;
 
-            _ = rdr.SwapStack(initialStack);
+            rdr.ReplaceStack(initialStack);
 
             if (leftState is EitherSideState.Error && rightState is EitherSideState.Error)
                 return Error(errorMessage ?? "Invalid JSON value.");

--- a/src/Utf8JsonReader.cs
+++ b/src/Utf8JsonReader.cs
@@ -34,10 +34,10 @@ public ref struct Utf8JsonReader
     public static ref System.Text.Json.Utf8JsonReader GetInnerReader(ref Utf8JsonReader reader) => ref reader.reader;
 
     public Utf8JsonReader(ReadOnlySpan<byte> jsonData, JsonReaderOptions options = default) :
-        this(new System.Text.Json.Utf8JsonReader(jsonData, options), stack: null) { }
+        this(new(jsonData, options), stack: null) { }
 
     public Utf8JsonReader(ReadOnlySpan<byte> jsonData, bool isFinalBlock, JsonReaderState state) :
-        this(new System.Text.Json.Utf8JsonReader(jsonData, isFinalBlock, state.InnerState), state.Stack) { }
+        this(new(jsonData, isFinalBlock, state.InnerState), state.Stack) { }
 
     Utf8JsonReader(System.Text.Json.Utf8JsonReader reader, Stack<object>? stack)
     {

--- a/src/Utf8JsonReader.cs
+++ b/src/Utf8JsonReader.cs
@@ -58,7 +58,7 @@ public ref struct Utf8JsonReader
     public T ResumeOrDefault<T>() where T : struct =>
         this.stack?.Count > 0 ? (T)Pop() : default;
 
-    public void ReplaceStack(Stack<object>? stack) =>
+    public void SetStack(Stack<object>? stack) =>
         this.stack = stack;
 
     public bool Read() => this.reader.Read();

--- a/src/Utf8JsonReader.cs
+++ b/src/Utf8JsonReader.cs
@@ -34,10 +34,13 @@ public ref struct Utf8JsonReader
     public static ref System.Text.Json.Utf8JsonReader GetInnerReader(ref Utf8JsonReader reader) => ref reader.reader;
 
     public Utf8JsonReader(ReadOnlySpan<byte> jsonData, JsonReaderOptions options = default) :
-        this(new(jsonData, options), stack: null) { }
+        this(new System.Text.Json.Utf8JsonReader(jsonData, options), stack: null) { }
 
     public Utf8JsonReader(ReadOnlySpan<byte> jsonData, bool isFinalBlock, JsonReaderState state) :
-        this(new(jsonData, isFinalBlock, state.InnerState), state.Stack) { }
+        this(new System.Text.Json.Utf8JsonReader(jsonData, isFinalBlock, state.InnerState), state.Stack) { }
+
+    public Utf8JsonReader(Utf8JsonReader reader, Stack<object>? stack) :
+        this(reader.reader, stack) { }
 
     Utf8JsonReader(System.Text.Json.Utf8JsonReader reader, Stack<object>? stack)
     {

--- a/src/Utf8JsonReader.cs
+++ b/src/Utf8JsonReader.cs
@@ -58,12 +58,8 @@ public ref struct Utf8JsonReader
     public T ResumeOrDefault<T>() where T : struct =>
         this.stack?.Count > 0 ? (T)Pop() : default;
 
-    public Stack<object>? SwapStack(Stack<object>? stack)
-    {
-        var result = this.stack;
+    public void ReplaceStack(Stack<object>? stack) =>
         this.stack = stack;
-        return result;
-    }
 
     public bool Read() => this.reader.Read();
 

--- a/src/Utf8JsonReader.cs
+++ b/src/Utf8JsonReader.cs
@@ -39,9 +39,6 @@ public ref struct Utf8JsonReader
     public Utf8JsonReader(ReadOnlySpan<byte> jsonData, bool isFinalBlock, JsonReaderState state) :
         this(new System.Text.Json.Utf8JsonReader(jsonData, isFinalBlock, state.InnerState), state.Stack) { }
 
-    public Utf8JsonReader(Utf8JsonReader reader, Stack<object>? stack) :
-        this(reader.reader, stack) { }
-
     Utf8JsonReader(System.Text.Json.Utf8JsonReader reader, Stack<object>? stack)
     {
         this.stack = stack;
@@ -60,6 +57,13 @@ public ref struct Utf8JsonReader
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public T ResumeOrDefault<T>() where T : struct =>
         this.stack?.Count > 0 ? (T)Pop() : default;
+
+    public Stack<object>? SwapStack(Stack<object>? stack)
+    {
+        var result = this.stack;
+        this.stack = stack;
+        return result;
+    }
 
     public bool Read() => this.reader.Read();
 

--- a/tests/JsonReaderTests.cs
+++ b/tests/JsonReaderTests.cs
@@ -744,6 +744,23 @@ public abstract class JsonReaderTestsBase
         TestValidInput(reader, json, expected);
     }
 
+    public static readonly TheoryData<object, string> Either_Of_Array_With_Valid_Input_Data =
+        new()
+        {
+            { new[] { "foo", "bar", "baz" }, /*lang=json*/ """["foo", "bar", "baz"]""" },
+            { new[] { 1, 2, 3, 4, 5 }, /*lang=json*/ """[1, 2, 3, 4, 5]""" },
+        };
+
+    [Theory]
+    [MemberData(nameof(Either_Of_Array_With_Valid_Input_Data))]
+    public void Either_Of_Array_With_Valid_Input(object expected, string json)
+    {
+        var reader =
+            JsonReader.Either(JsonReader.Array(JsonReader.String().AsObject()),
+                              JsonReader.Array(JsonReader.Int32().AsObject())).AsObject();
+        TestValidInput(reader, json, expected);
+    }
+
 #pragma warning disable CA1008 // Enums should have zero value (by-design)
     public enum LoRaBandwidth
 #pragma warning restore CA1008 // Enums should have zero value

--- a/tests/JsonReaderTests.cs
+++ b/tests/JsonReaderTests.cs
@@ -744,23 +744,6 @@ public abstract class JsonReaderTestsBase
         TestValidInput(reader, json, expected);
     }
 
-    public static readonly TheoryData<object, string> Either_Of_Array_With_Valid_Input_Data =
-        new()
-        {
-            { new[] { "foo", "bar", "baz" }, /*lang=json*/ """["foo", "bar", "baz"]""" },
-            { new[] { 1, 2, 3, 4, 5 }, /*lang=json*/ """[1, 2, 3, 4, 5]""" },
-        };
-
-    [Theory]
-    [MemberData(nameof(Either_Of_Array_With_Valid_Input_Data))]
-    public void Either_Of_Array_With_Valid_Input(object expected, string json)
-    {
-        var reader =
-            JsonReader.Either(JsonReader.Array(JsonReader.String().AsObject()),
-                              JsonReader.Array(JsonReader.Int32().AsObject())).AsObject();
-        TestValidInput(reader, json, expected);
-    }
-
 #pragma warning disable CA1008 // Enums should have zero value (by-design)
     public enum LoRaBandwidth
 #pragma warning restore CA1008 // Enums should have zero value


### PR DESCRIPTION
This PR introduces partial JSON reading support for all `JsonReader.Either` overloads.