### PR TITLE
Drop .NET Core 3.1 target that's reached end-of-life

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,13 +25,11 @@ install:
     if ($isWindows) {
       ./dotnet-install.ps1 -JsonFile global.json
       ./dotnet-install.ps1 -Version 6.0.11 -Runtime dotnet
-      ./dotnet-install.ps1 -Version 3.1.22 -Runtime dotnet
     }
 - sh: curl -OsSL https://dot.net/v1/dotnet-install.sh
 - sh: chmod +x dotnet-install.sh
 - sh: ./dotnet-install.sh --jsonfile global.json
 - sh: ./dotnet-install.sh --version 6.0.11 --runtime dotnet
-- sh: ./dotnet-install.sh --version 3.1.22 --runtime dotnet
 - sh: export PATH="$HOME/.dotnet:$PATH"
 before_build:
 - dotnet --info

--- a/src/Jacob.csproj
+++ b/src/Jacob.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <VersionPrefix>0.6.0</VersionPrefix>
     <Description>A succinct and compositional .NET API for reading JSON.</Description>
     <Authors>Atif Aziz</Authors>

--- a/tests/Jacob.Tests.csproj
+++ b/tests/Jacob.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/JsonReaderTests.cs
+++ b/tests/JsonReaderTests.cs
@@ -1095,14 +1095,7 @@ public abstract class JsonReaderTestsBase
     {
         var actual = JsonReader.Element().Read(json);
         var reader = new System.Text.Json.Utf8JsonReader(Encoding.UTF8.GetBytes(json));
-#if NET6_0_OR_GREATER
         var expected = JsonElement.ParseValue(ref reader);
-#elif NETCOREAPP3_1_OR_GREATER
-        using var doc = JsonDocument.ParseValue(ref reader);
-        var expected = doc.RootElement.Clone();
-#else
-#error Unsupported platform.
-#endif
         Assert.Equal(expected.ToString(), actual.ToString());
     }
 


### PR DESCRIPTION
This PR drops the .NET Core 3.1 target that [reached end-of-life on December 13, 2022](https://learn.microsoft.com/en-us/lifecycle/products/microsoft-net-and-net-core).
